### PR TITLE
Fixed some theme issues and added all markup and styles necessary for project search

### DIFF
--- a/config/dev-active/layout.layout.home.json
+++ b/config/dev-active/layout.layout.home.json
@@ -210,16 +210,21 @@
                 "settings": {
                     "title_display": "default",
                     "title": "",
-                    "style": "default",
+                    "style": "dynamic",
                     "block_settings": [],
                     "contexts": []
                 },
                 "uuid": "712c691e-6273-4634-8000-d97d82d86e88",
                 "style": {
-                    "plugin": "default",
+                    "plugin": "dynamic",
                     "data": {
                         "settings": {
-                            "classes": ""
+                            "classes": "l-content-wrapper",
+                            "wrapper_tag": "div",
+                            "title_tag": "h2",
+                            "title_classes": "block-title",
+                            "content_tag": "div",
+                            "content_classes": ""
                         }
                     }
                 }
@@ -265,7 +270,7 @@
                     "plugin": "default",
                     "data": {
                         "settings": {
-                            "classes": ""
+                            "classes": "l-content-wrapper"
                         }
                     }
                 }
@@ -279,16 +284,21 @@
                 "settings": {
                     "title_display": "custom",
                     "title": "Show your support for Backdrop CMS",
-                    "style": "default",
+                    "style": "dynamic",
                     "block_settings": [],
                     "contexts": []
                 },
                 "uuid": "eb9135d6-652f-45c3-9a00-c8de2519591d",
                 "style": {
-                    "plugin": "default",
+                    "plugin": "dynamic",
                     "data": {
                         "settings": {
-                            "classes": ""
+                            "classes": "",
+                            "wrapper_tag": "div",
+                            "title_tag": "h2",
+                            "title_classes": "block-title l-content-wrapper",
+                            "content_tag": "div",
+                            "content_classes": "l-content-wrapper"
                         }
                     }
                 }

--- a/config/dev-active/layout.layout.search_layouts.json
+++ b/config/dev-active/layout.layout.search_layouts.json
@@ -1,12 +1,12 @@
 {
-    "_config_name": "layout.layout.default",
-    "path": "",
-    "name": "default",
-    "title": "Default Layout",
+    "_config_name": "layout.layout.search_layouts",
+    "path": "layouts",
+    "name": "search_layouts",
+    "title": "Search layouts",
     "description": null,
-    "module": "layout",
-    "weight": 0,
-    "storage": 2,
+    "module": null,
+    "weight": -3,
+    "storage": 1,
     "layout": "double_fixed",
     "disabled": false,
     "settings": {
@@ -16,25 +16,25 @@
     },
     "positions": {
         "sidebar": [
-            "6af74ef4-4c62-472a-aa00-d12b128df6d2",
-            "9d4d7374-2a8e-4218-8b22-3440dc62a2ff"
+            "75caabc2-e0d6-4967-b000-ff477e009c65",
+            "0b7ea9cd-3070-46d8-8d4d-772314d6c5d2"
         ],
         "drawer": [
-            "8a85d3c6-059e-4ca7-ac62-989a4d3f6476",
-            "5058cb9f-cd84-4ae0-994c-769ace157a7f"
+            "80347e42-1c9e-4ec2-8d08-8c7e927d1e46",
+            "423b3561-144b-4f2c-bf02-2de6178f086e"
         ],
         "content-top": [],
         "content": [
-            "default"
+            "6c84409f-e0f6-45f2-a705-5bf43bc4fce2"
         ],
         "footer": [
-            "3f6bea0b-e674-4374-8103-3ab4762617fb",
-            "58a52df4-ec8f-441b-a463-994fe39766df",
-            "eb93f363-d005-418b-9b00-f54abc7e0625"
+            "58a1ce1e-173f-453b-9800-da1e2ee14a88",
+            "5a84421a-b5a3-43e4-b000-a2f8de7fc3c7",
+            "598c4f0b-0d86-41ea-b600-c6c9d99679ed"
         ]
     },
     "content": {
-        "6af74ef4-4c62-472a-aa00-d12b128df6d2": {
+        "75caabc2-e0d6-4967-b000-ff477e009c65": {
             "plugin": "borg_blocks:branding",
             "data": {
                 "module": "borg_blocks",
@@ -46,7 +46,7 @@
                     "block_settings": [],
                     "contexts": []
                 },
-                "uuid": "6af74ef4-4c62-472a-aa00-d12b128df6d2",
+                "uuid": "75caabc2-e0d6-4967-b000-ff477e009c65",
                 "style": {
                     "plugin": "default",
                     "data": {
@@ -57,7 +57,7 @@
                 }
             }
         },
-        "9d4d7374-2a8e-4218-8b22-3440dc62a2ff": {
+        "0b7ea9cd-3070-46d8-8d4d-772314d6c5d2": {
             "plugin": "system:main-menu",
             "data": {
                 "module": "system",
@@ -69,7 +69,7 @@
                     "block_settings": [],
                     "contexts": []
                 },
-                "uuid": "9d4d7374-2a8e-4218-8b22-3440dc62a2ff",
+                "uuid": "0b7ea9cd-3070-46d8-8d4d-772314d6c5d2",
                 "style": {
                     "plugin": "default",
                     "data": {
@@ -80,7 +80,7 @@
                 }
             }
         },
-        "8a85d3c6-059e-4ca7-ac62-989a4d3f6476": {
+        "80347e42-1c9e-4ec2-8d08-8c7e927d1e46": {
             "plugin": "borg_blocks:handbook",
             "data": {
                 "module": "borg_blocks",
@@ -92,7 +92,7 @@
                     "block_settings": [],
                     "contexts": []
                 },
-                "uuid": "8a85d3c6-059e-4ca7-ac62-989a4d3f6476",
+                "uuid": "80347e42-1c9e-4ec2-8d08-8c7e927d1e46",
                 "style": {
                     "plugin": "default",
                     "data": {
@@ -103,7 +103,7 @@
                 }
             }
         },
-        "5058cb9f-cd84-4ae0-994c-769ace157a7f": {
+        "423b3561-144b-4f2c-bf02-2de6178f086e": {
             "plugin": "search:form",
             "data": {
                 "module": "search",
@@ -115,7 +115,7 @@
                     "block_settings": [],
                     "contexts": []
                 },
-                "uuid": "5058cb9f-cd84-4ae0-994c-769ace157a7f",
+                "uuid": "423b3561-144b-4f2c-bf02-2de6178f086e",
                 "style": {
                     "plugin": "default",
                     "data": {
@@ -126,7 +126,7 @@
                 }
             }
         },
-        "default": {
+        "6c84409f-e0f6-45f2-a705-5bf43bc4fce2": {
             "plugin": "system:main",
             "data": {
                 "module": "system",
@@ -134,27 +134,22 @@
                 "settings": {
                     "title_display": "default",
                     "title": "",
-                    "style": "dynamic",
+                    "style": "default",
                     "block_settings": [],
                     "contexts": []
                 },
-                "uuid": "default",
+                "uuid": "6c84409f-e0f6-45f2-a705-5bf43bc4fce2",
                 "style": {
-                    "plugin": "dynamic",
+                    "plugin": "default",
                     "data": {
                         "settings": {
-                            "classes": "l-content-wrapper",
-                            "wrapper_tag": "div",
-                            "title_tag": "h2",
-                            "title_classes": "block-title",
-                            "content_tag": "div",
-                            "content_classes": ""
+                            "classes": ""
                         }
                     }
                 }
             }
         },
-        "3f6bea0b-e674-4374-8103-3ab4762617fb": {
+        "58a1ce1e-173f-453b-9800-da1e2ee14a88": {
             "plugin": "block:3",
             "data": {
                 "module": "block",
@@ -166,7 +161,7 @@
                     "block_settings": [],
                     "contexts": []
                 },
-                "uuid": "3f6bea0b-e674-4374-8103-3ab4762617fb",
+                "uuid": "58a1ce1e-173f-453b-9800-da1e2ee14a88",
                 "style": {
                     "plugin": "default",
                     "data": {
@@ -177,7 +172,7 @@
                 }
             }
         },
-        "58a52df4-ec8f-441b-a463-994fe39766df": {
+        "5a84421a-b5a3-43e4-b000-a2f8de7fc3c7": {
             "plugin": "on_the_web:social_links",
             "data": {
                 "module": "on_the_web",
@@ -199,7 +194,7 @@
                     },
                     "contexts": []
                 },
-                "uuid": "58a52df4-ec8f-441b-a463-994fe39766df",
+                "uuid": "5a84421a-b5a3-43e4-b000-a2f8de7fc3c7",
                 "style": {
                     "plugin": "default",
                     "data": {
@@ -210,7 +205,7 @@
                 }
             }
         },
-        "eb93f363-d005-418b-9b00-f54abc7e0625": {
+        "598c4f0b-0d86-41ea-b600-c6c9d99679ed": {
             "plugin": "block:5",
             "data": {
                 "module": "block",
@@ -222,7 +217,7 @@
                     "block_settings": [],
                     "contexts": []
                 },
-                "uuid": "eb93f363-d005-418b-9b00-f54abc7e0625",
+                "uuid": "598c4f0b-0d86-41ea-b600-c6c9d99679ed",
                 "style": {
                     "plugin": "default",
                     "data": {

--- a/config/dev-active/layout.layout.search_modules.json
+++ b/config/dev-active/layout.layout.search_modules.json
@@ -1,12 +1,12 @@
 {
-    "_config_name": "layout.layout.default",
-    "path": "",
-    "name": "default",
-    "title": "Default Layout",
+    "_config_name": "layout.layout.search_modules",
+    "path": "modules",
+    "name": "search_modules",
+    "title": "Search Modules",
     "description": null,
-    "module": "layout",
-    "weight": 0,
-    "storage": 2,
+    "module": null,
+    "weight": -2,
+    "storage": 1,
     "layout": "double_fixed",
     "disabled": false,
     "settings": {
@@ -16,25 +16,25 @@
     },
     "positions": {
         "sidebar": [
-            "6af74ef4-4c62-472a-aa00-d12b128df6d2",
-            "9d4d7374-2a8e-4218-8b22-3440dc62a2ff"
+            "dcc08931-fe27-45e8-8a09-9ea6d72e5fa2",
+            "1b3a6d21-38e2-4794-9300-b8f01bbe34fb"
         ],
         "drawer": [
-            "8a85d3c6-059e-4ca7-ac62-989a4d3f6476",
-            "5058cb9f-cd84-4ae0-994c-769ace157a7f"
+            "e470526e-403a-46dc-9d00-e4d302e44088",
+            "64a6ef50-73e1-4075-a200-bd39a1f312f1"
         ],
         "content-top": [],
         "content": [
-            "default"
+            "7dd5f366-d6f5-4333-bc00-0cf61eb8b873"
         ],
         "footer": [
-            "3f6bea0b-e674-4374-8103-3ab4762617fb",
-            "58a52df4-ec8f-441b-a463-994fe39766df",
-            "eb93f363-d005-418b-9b00-f54abc7e0625"
+            "c8dcf840-64d3-48f9-a007-7aaca560f9d3",
+            "47d4f23d-79a4-4271-b100-0b50cbeeaf53",
+            "2ad0172c-3184-484e-af5d-935381f16c20"
         ]
     },
     "content": {
-        "6af74ef4-4c62-472a-aa00-d12b128df6d2": {
+        "dcc08931-fe27-45e8-8a09-9ea6d72e5fa2": {
             "plugin": "borg_blocks:branding",
             "data": {
                 "module": "borg_blocks",
@@ -46,7 +46,7 @@
                     "block_settings": [],
                     "contexts": []
                 },
-                "uuid": "6af74ef4-4c62-472a-aa00-d12b128df6d2",
+                "uuid": "dcc08931-fe27-45e8-8a09-9ea6d72e5fa2",
                 "style": {
                     "plugin": "default",
                     "data": {
@@ -57,7 +57,7 @@
                 }
             }
         },
-        "9d4d7374-2a8e-4218-8b22-3440dc62a2ff": {
+        "1b3a6d21-38e2-4794-9300-b8f01bbe34fb": {
             "plugin": "system:main-menu",
             "data": {
                 "module": "system",
@@ -69,7 +69,7 @@
                     "block_settings": [],
                     "contexts": []
                 },
-                "uuid": "9d4d7374-2a8e-4218-8b22-3440dc62a2ff",
+                "uuid": "1b3a6d21-38e2-4794-9300-b8f01bbe34fb",
                 "style": {
                     "plugin": "default",
                     "data": {
@@ -80,7 +80,7 @@
                 }
             }
         },
-        "8a85d3c6-059e-4ca7-ac62-989a4d3f6476": {
+        "e470526e-403a-46dc-9d00-e4d302e44088": {
             "plugin": "borg_blocks:handbook",
             "data": {
                 "module": "borg_blocks",
@@ -92,7 +92,7 @@
                     "block_settings": [],
                     "contexts": []
                 },
-                "uuid": "8a85d3c6-059e-4ca7-ac62-989a4d3f6476",
+                "uuid": "e470526e-403a-46dc-9d00-e4d302e44088",
                 "style": {
                     "plugin": "default",
                     "data": {
@@ -103,7 +103,7 @@
                 }
             }
         },
-        "5058cb9f-cd84-4ae0-994c-769ace157a7f": {
+        "64a6ef50-73e1-4075-a200-bd39a1f312f1": {
             "plugin": "search:form",
             "data": {
                 "module": "search",
@@ -115,7 +115,7 @@
                     "block_settings": [],
                     "contexts": []
                 },
-                "uuid": "5058cb9f-cd84-4ae0-994c-769ace157a7f",
+                "uuid": "64a6ef50-73e1-4075-a200-bd39a1f312f1",
                 "style": {
                     "plugin": "default",
                     "data": {
@@ -126,7 +126,7 @@
                 }
             }
         },
-        "default": {
+        "7dd5f366-d6f5-4333-bc00-0cf61eb8b873": {
             "plugin": "system:main",
             "data": {
                 "module": "system",
@@ -134,27 +134,22 @@
                 "settings": {
                     "title_display": "default",
                     "title": "",
-                    "style": "dynamic",
+                    "style": "default",
                     "block_settings": [],
                     "contexts": []
                 },
-                "uuid": "default",
+                "uuid": "7dd5f366-d6f5-4333-bc00-0cf61eb8b873",
                 "style": {
-                    "plugin": "dynamic",
+                    "plugin": "default",
                     "data": {
                         "settings": {
-                            "classes": "l-content-wrapper",
-                            "wrapper_tag": "div",
-                            "title_tag": "h2",
-                            "title_classes": "block-title",
-                            "content_tag": "div",
-                            "content_classes": ""
+                            "classes": ""
                         }
                     }
                 }
             }
         },
-        "3f6bea0b-e674-4374-8103-3ab4762617fb": {
+        "c8dcf840-64d3-48f9-a007-7aaca560f9d3": {
             "plugin": "block:3",
             "data": {
                 "module": "block",
@@ -166,7 +161,7 @@
                     "block_settings": [],
                     "contexts": []
                 },
-                "uuid": "3f6bea0b-e674-4374-8103-3ab4762617fb",
+                "uuid": "c8dcf840-64d3-48f9-a007-7aaca560f9d3",
                 "style": {
                     "plugin": "default",
                     "data": {
@@ -177,7 +172,7 @@
                 }
             }
         },
-        "58a52df4-ec8f-441b-a463-994fe39766df": {
+        "47d4f23d-79a4-4271-b100-0b50cbeeaf53": {
             "plugin": "on_the_web:social_links",
             "data": {
                 "module": "on_the_web",
@@ -199,7 +194,7 @@
                     },
                     "contexts": []
                 },
-                "uuid": "58a52df4-ec8f-441b-a463-994fe39766df",
+                "uuid": "47d4f23d-79a4-4271-b100-0b50cbeeaf53",
                 "style": {
                     "plugin": "default",
                     "data": {
@@ -210,7 +205,7 @@
                 }
             }
         },
-        "eb93f363-d005-418b-9b00-f54abc7e0625": {
+        "2ad0172c-3184-484e-af5d-935381f16c20": {
             "plugin": "block:5",
             "data": {
                 "module": "block",
@@ -222,7 +217,7 @@
                     "block_settings": [],
                     "contexts": []
                 },
-                "uuid": "eb93f363-d005-418b-9b00-f54abc7e0625",
+                "uuid": "2ad0172c-3184-484e-af5d-935381f16c20",
                 "style": {
                     "plugin": "default",
                     "data": {

--- a/config/dev-active/layout.layout.search_themes.json
+++ b/config/dev-active/layout.layout.search_themes.json
@@ -1,12 +1,12 @@
 {
-    "_config_name": "layout.layout.default",
-    "path": "",
-    "name": "default",
-    "title": "Default Layout",
+    "_config_name": "layout.layout.search_themes",
+    "path": "themes",
+    "name": "search_themes",
+    "title": "Search Themes",
     "description": null,
-    "module": "layout",
-    "weight": 0,
-    "storage": 2,
+    "module": null,
+    "weight": -1,
+    "storage": 1,
     "layout": "double_fixed",
     "disabled": false,
     "settings": {
@@ -16,25 +16,25 @@
     },
     "positions": {
         "sidebar": [
-            "6af74ef4-4c62-472a-aa00-d12b128df6d2",
-            "9d4d7374-2a8e-4218-8b22-3440dc62a2ff"
+            "7644abf7-1b15-49e5-b305-5afeb39d23c2",
+            "81f6346a-fb64-4a5d-8605-5ded96d0202e"
         ],
         "drawer": [
-            "8a85d3c6-059e-4ca7-ac62-989a4d3f6476",
-            "5058cb9f-cd84-4ae0-994c-769ace157a7f"
+            "9a508af9-ce88-426c-b611-1739bbbf5382",
+            "8659af0e-d0ac-436c-9b00-e6c4f0f1c987"
         ],
         "content-top": [],
         "content": [
-            "default"
+            "1370551a-8ba1-435e-ab15-21f558c45013"
         ],
         "footer": [
-            "3f6bea0b-e674-4374-8103-3ab4762617fb",
-            "58a52df4-ec8f-441b-a463-994fe39766df",
-            "eb93f363-d005-418b-9b00-f54abc7e0625"
+            "8cfef68d-7527-4538-b026-3826cad24eee",
+            "7165b9a8-723c-4d24-ad5c-929e239f006d",
+            "deb1a640-0413-448e-b000-0c93612bb5ba"
         ]
     },
     "content": {
-        "6af74ef4-4c62-472a-aa00-d12b128df6d2": {
+        "7644abf7-1b15-49e5-b305-5afeb39d23c2": {
             "plugin": "borg_blocks:branding",
             "data": {
                 "module": "borg_blocks",
@@ -46,7 +46,7 @@
                     "block_settings": [],
                     "contexts": []
                 },
-                "uuid": "6af74ef4-4c62-472a-aa00-d12b128df6d2",
+                "uuid": "7644abf7-1b15-49e5-b305-5afeb39d23c2",
                 "style": {
                     "plugin": "default",
                     "data": {
@@ -57,7 +57,7 @@
                 }
             }
         },
-        "9d4d7374-2a8e-4218-8b22-3440dc62a2ff": {
+        "81f6346a-fb64-4a5d-8605-5ded96d0202e": {
             "plugin": "system:main-menu",
             "data": {
                 "module": "system",
@@ -69,7 +69,7 @@
                     "block_settings": [],
                     "contexts": []
                 },
-                "uuid": "9d4d7374-2a8e-4218-8b22-3440dc62a2ff",
+                "uuid": "81f6346a-fb64-4a5d-8605-5ded96d0202e",
                 "style": {
                     "plugin": "default",
                     "data": {
@@ -80,7 +80,7 @@
                 }
             }
         },
-        "8a85d3c6-059e-4ca7-ac62-989a4d3f6476": {
+        "9a508af9-ce88-426c-b611-1739bbbf5382": {
             "plugin": "borg_blocks:handbook",
             "data": {
                 "module": "borg_blocks",
@@ -92,7 +92,7 @@
                     "block_settings": [],
                     "contexts": []
                 },
-                "uuid": "8a85d3c6-059e-4ca7-ac62-989a4d3f6476",
+                "uuid": "9a508af9-ce88-426c-b611-1739bbbf5382",
                 "style": {
                     "plugin": "default",
                     "data": {
@@ -103,7 +103,7 @@
                 }
             }
         },
-        "5058cb9f-cd84-4ae0-994c-769ace157a7f": {
+        "8659af0e-d0ac-436c-9b00-e6c4f0f1c987": {
             "plugin": "search:form",
             "data": {
                 "module": "search",
@@ -115,7 +115,7 @@
                     "block_settings": [],
                     "contexts": []
                 },
-                "uuid": "5058cb9f-cd84-4ae0-994c-769ace157a7f",
+                "uuid": "8659af0e-d0ac-436c-9b00-e6c4f0f1c987",
                 "style": {
                     "plugin": "default",
                     "data": {
@@ -126,7 +126,7 @@
                 }
             }
         },
-        "default": {
+        "1370551a-8ba1-435e-ab15-21f558c45013": {
             "plugin": "system:main",
             "data": {
                 "module": "system",
@@ -134,27 +134,22 @@
                 "settings": {
                     "title_display": "default",
                     "title": "",
-                    "style": "dynamic",
+                    "style": "default",
                     "block_settings": [],
                     "contexts": []
                 },
-                "uuid": "default",
+                "uuid": "1370551a-8ba1-435e-ab15-21f558c45013",
                 "style": {
-                    "plugin": "dynamic",
+                    "plugin": "default",
                     "data": {
                         "settings": {
-                            "classes": "l-content-wrapper",
-                            "wrapper_tag": "div",
-                            "title_tag": "h2",
-                            "title_classes": "block-title",
-                            "content_tag": "div",
-                            "content_classes": ""
+                            "classes": ""
                         }
                     }
                 }
             }
         },
-        "3f6bea0b-e674-4374-8103-3ab4762617fb": {
+        "8cfef68d-7527-4538-b026-3826cad24eee": {
             "plugin": "block:3",
             "data": {
                 "module": "block",
@@ -166,7 +161,7 @@
                     "block_settings": [],
                     "contexts": []
                 },
-                "uuid": "3f6bea0b-e674-4374-8103-3ab4762617fb",
+                "uuid": "8cfef68d-7527-4538-b026-3826cad24eee",
                 "style": {
                     "plugin": "default",
                     "data": {
@@ -177,7 +172,7 @@
                 }
             }
         },
-        "58a52df4-ec8f-441b-a463-994fe39766df": {
+        "7165b9a8-723c-4d24-ad5c-929e239f006d": {
             "plugin": "on_the_web:social_links",
             "data": {
                 "module": "on_the_web",
@@ -199,7 +194,7 @@
                     },
                     "contexts": []
                 },
-                "uuid": "58a52df4-ec8f-441b-a463-994fe39766df",
+                "uuid": "7165b9a8-723c-4d24-ad5c-929e239f006d",
                 "style": {
                     "plugin": "default",
                     "data": {
@@ -210,7 +205,7 @@
                 }
             }
         },
-        "eb93f363-d005-418b-9b00-f54abc7e0625": {
+        "deb1a640-0413-448e-b000-0c93612bb5ba": {
             "plugin": "block:5",
             "data": {
                 "module": "block",
@@ -222,7 +217,7 @@
                     "block_settings": [],
                     "contexts": []
                 },
-                "uuid": "eb93f363-d005-418b-9b00-f54abc7e0625",
+                "uuid": "deb1a640-0413-448e-b000-0c93612bb5ba",
                 "style": {
                     "plugin": "default",
                     "data": {

--- a/config/dev-active/views.view.modules.json
+++ b/config/dev-active/views.view.modules.json
@@ -1,0 +1,851 @@
+{
+    "_config_name": "views.view.modules",
+    "name": "modules",
+    "description": "",
+    "tag": "default",
+    "disabled": false,
+    "base_table": "node",
+    "human_name": "modules",
+    "core": "1.1.2",
+    "display": {
+        "default": {
+            "display_title": "Master",
+            "display_plugin": "default",
+            "display_options": {
+                "query": {
+                    "type": "views_query",
+                    "options": []
+                },
+                "access": {
+                    "type": "none"
+                },
+                "cache": {
+                    "type": "none"
+                },
+                "exposed_form": {
+                    "type": "basic",
+                    "options": {
+                        "submit_button": "Search",
+                        "reset_button": 0,
+                        "reset_button_label": "Reset",
+                        "exposed_sorts_label": "Sort by",
+                        "expose_sort_order": 1,
+                        "sort_asc_label": "Asc",
+                        "sort_desc_label": "Desc",
+                        "autosubmit": 0,
+                        "autosubmit_hide": 1
+                    }
+                },
+                "pager": {
+                    "type": "full",
+                    "options": {
+                        "items_per_page": "25",
+                        "offset": "0",
+                        "id": "0",
+                        "total_pages": "",
+                        "quantity": "9",
+                        "tags": {
+                            "first": "« first",
+                            "previous": "‹ previous",
+                            "next": "next ›",
+                            "last": "last »"
+                        },
+                        "expose": {
+                            "items_per_page": 0,
+                            "items_per_page_label": "Items per page",
+                            "items_per_page_options": "5, 10, 20, 40, 60",
+                            "items_per_page_options_all": 0,
+                            "items_per_page_options_all_label": "- All -",
+                            "offset": 0,
+                            "offset_label": "Offset"
+                        }
+                    }
+                },
+                "style_plugin": "list",
+                "row_plugin": "fields",
+                "fields": {
+                    "title": {
+                        "id": "title",
+                        "table": "node",
+                        "field": "title",
+                        "relationship": "none",
+                        "group_type": "group",
+                        "ui_name": "",
+                        "label": "",
+                        "exclude": 0,
+                        "alter": {
+                            "alter_text": 0,
+                            "text": "",
+                            "make_link": 0,
+                            "path": "",
+                            "absolute": 0,
+                            "external": 0,
+                            "replace_spaces": 0,
+                            "path_case": "none",
+                            "trim_whitespace": 0,
+                            "alt": "",
+                            "rel": "",
+                            "link_class": "",
+                            "prefix": "",
+                            "suffix": "",
+                            "target": "",
+                            "nl2br": 0,
+                            "max_length": "",
+                            "word_boundary": 0,
+                            "ellipsis": 0,
+                            "more_link": 0,
+                            "more_link_text": "",
+                            "more_link_path": "",
+                            "strip_tags": 0,
+                            "trim": 0,
+                            "preserve_tags": "",
+                            "html": 0
+                        },
+                        "element_type": "h3",
+                        "element_class": "",
+                        "element_label_type": "",
+                        "element_label_class": "",
+                        "element_label_colon": false,
+                        "element_wrapper_type": "",
+                        "element_wrapper_class": "",
+                        "element_default_classes": 1,
+                        "empty": "",
+                        "hide_empty": 0,
+                        "empty_zero": 0,
+                        "hide_alter_empty": 1,
+                        "link_to_node": 1
+                    },
+                    "body": {
+                        "id": "body",
+                        "table": "field_data_body",
+                        "field": "body",
+                        "relationship": "none",
+                        "group_type": "group",
+                        "ui_name": "",
+                        "label": "",
+                        "exclude": 0,
+                        "alter": {
+                            "alter_text": 0,
+                            "text": "[body]...",
+                            "make_link": 0,
+                            "path": "",
+                            "absolute": 0,
+                            "external": 0,
+                            "replace_spaces": 0,
+                            "path_case": "none",
+                            "trim_whitespace": 0,
+                            "alt": "",
+                            "rel": "",
+                            "link_class": "",
+                            "prefix": "",
+                            "suffix": "",
+                            "target": "",
+                            "nl2br": 0,
+                            "max_length": "",
+                            "word_boundary": 1,
+                            "ellipsis": 1,
+                            "more_link": 0,
+                            "more_link_text": "",
+                            "more_link_path": "",
+                            "strip_tags": 1,
+                            "trim": 0,
+                            "preserve_tags": "<a><p><br>",
+                            "html": 0
+                        },
+                        "element_type": "",
+                        "element_class": "",
+                        "element_label_type": "",
+                        "element_label_class": "",
+                        "element_label_colon": false,
+                        "element_wrapper_type": "",
+                        "element_wrapper_class": "",
+                        "element_default_classes": 1,
+                        "empty": "",
+                        "hide_empty": 0,
+                        "empty_zero": 0,
+                        "hide_alter_empty": 1,
+                        "click_sort_column": "value",
+                        "type": "text_trimmed",
+                        "settings": {
+                            "trim_length": "300"
+                        },
+                        "group_column": "value",
+                        "group_columns": [],
+                        "group_rows": true,
+                        "delta_limit": "all",
+                        "delta_offset": 0,
+                        "delta_reversed": false,
+                        "delta_first_last": false,
+                        "multi_type": "separator",
+                        "separator": ", ",
+                        "field_api_classes": 0
+                    },
+                    "download_link": {
+                        "id": "download_link",
+                        "table": "project_release",
+                        "field": "download_link",
+                        "relationship": "project_releases",
+                        "group_type": "group",
+                        "ui_name": "",
+                        "label": "",
+                        "exclude": 1,
+                        "alter": {
+                            "alter_text": 0,
+                            "text": "",
+                            "make_link": 0,
+                            "path": "",
+                            "absolute": 0,
+                            "external": 0,
+                            "replace_spaces": 0,
+                            "path_case": "none",
+                            "trim_whitespace": 0,
+                            "alt": "",
+                            "rel": "",
+                            "link_class": "",
+                            "prefix": "",
+                            "suffix": "",
+                            "target": "",
+                            "nl2br": 0,
+                            "max_length": "",
+                            "word_boundary": 1,
+                            "ellipsis": 1,
+                            "more_link": 0,
+                            "more_link_text": "",
+                            "more_link_path": "",
+                            "strip_tags": 0,
+                            "trim": 0,
+                            "preserve_tags": "",
+                            "html": 0
+                        },
+                        "element_type": "",
+                        "element_class": "",
+                        "element_label_type": "",
+                        "element_label_class": "",
+                        "element_label_colon": false,
+                        "element_wrapper_type": "",
+                        "element_wrapper_class": "",
+                        "element_default_classes": 1,
+                        "empty": "",
+                        "hide_empty": 0,
+                        "empty_zero": 0,
+                        "hide_alter_empty": 1,
+                        "display_as_link": 0
+                    },
+                    "version": {
+                        "id": "version",
+                        "table": "project_release",
+                        "field": "version",
+                        "relationship": "project_releases",
+                        "group_type": "group",
+                        "ui_name": "",
+                        "label": "",
+                        "exclude": 0,
+                        "alter": {
+                            "alter_text": 1,
+                            "text": "<a href=\"[download_link]\">Download [version]</a>",
+                            "make_link": 0,
+                            "path": "",
+                            "absolute": 0,
+                            "external": 0,
+                            "replace_spaces": 0,
+                            "path_case": "none",
+                            "trim_whitespace": 0,
+                            "alt": "",
+                            "rel": "",
+                            "link_class": "",
+                            "prefix": "",
+                            "suffix": "",
+                            "target": "",
+                            "nl2br": 0,
+                            "max_length": "",
+                            "word_boundary": 1,
+                            "ellipsis": 1,
+                            "more_link": 0,
+                            "more_link_text": "",
+                            "more_link_path": "",
+                            "strip_tags": 0,
+                            "trim": 0,
+                            "preserve_tags": "",
+                            "html": 0
+                        },
+                        "element_type": "",
+                        "element_class": "",
+                        "element_label_type": "",
+                        "element_label_class": "",
+                        "element_label_colon": false,
+                        "element_wrapper_type": "",
+                        "element_wrapper_class": "",
+                        "element_default_classes": 1,
+                        "empty": "",
+                        "hide_empty": 0,
+                        "empty_zero": 0,
+                        "hide_alter_empty": 1
+                    },
+                    "download_size": {
+                        "id": "download_size",
+                        "table": "project_release",
+                        "field": "download_size",
+                        "relationship": "project_releases",
+                        "group_type": "group",
+                        "ui_name": "",
+                        "label": "",
+                        "exclude": 0,
+                        "alter": {
+                            "alter_text": 0,
+                            "text": "",
+                            "make_link": 0,
+                            "path": "",
+                            "absolute": 0,
+                            "external": 0,
+                            "replace_spaces": 0,
+                            "path_case": "none",
+                            "trim_whitespace": 0,
+                            "alt": "",
+                            "rel": "",
+                            "link_class": "",
+                            "prefix": "",
+                            "suffix": "",
+                            "target": "",
+                            "nl2br": 0,
+                            "max_length": "",
+                            "word_boundary": 1,
+                            "ellipsis": 1,
+                            "more_link": 0,
+                            "more_link_text": "",
+                            "more_link_path": "",
+                            "strip_tags": 0,
+                            "trim": 0,
+                            "preserve_tags": "",
+                            "html": 0
+                        },
+                        "element_type": "",
+                        "element_class": "",
+                        "element_label_type": "",
+                        "element_label_class": "",
+                        "element_label_colon": false,
+                        "element_wrapper_type": "",
+                        "element_wrapper_class": "",
+                        "element_default_classes": 1,
+                        "empty": "",
+                        "hide_empty": 0,
+                        "empty_zero": 0,
+                        "hide_alter_empty": 1,
+                        "file_size_display": "formatted"
+                    },
+                    "view_node": {
+                        "id": "view_node",
+                        "table": "views_entity_node",
+                        "field": "view_node",
+                        "relationship": "none",
+                        "group_type": "group",
+                        "ui_name": "",
+                        "label": "",
+                        "exclude": 0,
+                        "alter": {
+                            "alter_text": 0,
+                            "text": "",
+                            "make_link": 0,
+                            "path": "",
+                            "absolute": 0,
+                            "external": false,
+                            "replace_spaces": 0,
+                            "path_case": "none",
+                            "trim_whitespace": 0,
+                            "alt": "",
+                            "rel": "",
+                            "link_class": "",
+                            "prefix": "",
+                            "suffix": "",
+                            "target": "",
+                            "nl2br": 0,
+                            "max_length": "",
+                            "word_boundary": 1,
+                            "ellipsis": 1,
+                            "more_link": 0,
+                            "more_link_text": "",
+                            "more_link_path": "",
+                            "strip_tags": 0,
+                            "trim": 0,
+                            "preserve_tags": "",
+                            "html": 0
+                        },
+                        "element_type": "",
+                        "element_class": "",
+                        "element_label_type": "",
+                        "element_label_class": "",
+                        "element_label_colon": false,
+                        "element_wrapper_type": "",
+                        "element_wrapper_class": "",
+                        "element_default_classes": 1,
+                        "empty": "",
+                        "hide_empty": 0,
+                        "empty_zero": 0,
+                        "hide_alter_empty": 1,
+                        "text": "More Info"
+                    }
+                },
+                "filters": {
+                    "status": {
+                        "value": 1,
+                        "table": "node",
+                        "field": "status",
+                        "id": "status",
+                        "expose": {
+                            "operator": false
+                        },
+                        "group": 1
+                    },
+                    "type": {
+                        "id": "type",
+                        "table": "node",
+                        "field": "type",
+                        "relationship": "none",
+                        "group_type": "group",
+                        "ui_name": "",
+                        "operator": "in",
+                        "value": {
+                            "project_module": "project_module"
+                        },
+                        "group": "1",
+                        "exposed": false,
+                        "expose": {
+                            "operator_id": false,
+                            "label": "",
+                            "description": "",
+                            "use_operator": false,
+                            "operator": "",
+                            "identifier": "",
+                            "required": false,
+                            "remember": false,
+                            "multiple": false,
+                            "remember_roles": {
+                                "authenticated": "authenticated"
+                            },
+                            "reduce": false
+                        },
+                        "is_grouped": false,
+                        "group_info": {
+                            "label": "",
+                            "description": "",
+                            "identifier": "",
+                            "optional": true,
+                            "widget": "select",
+                            "multiple": false,
+                            "remember": 0,
+                            "default_group": "All",
+                            "default_group_multiple": [],
+                            "group_items": []
+                        }
+                    },
+                    "keys": {
+                        "id": "keys",
+                        "table": "search_index",
+                        "field": "keys",
+                        "relationship": "none",
+                        "group_type": "group",
+                        "ui_name": "",
+                        "operator": "optional",
+                        "value": "",
+                        "group": "1",
+                        "exposed": true,
+                        "expose": {
+                            "operator_id": "keys_op",
+                            "label": "",
+                            "description": "",
+                            "use_operator": 0,
+                            "operator": "keys_op",
+                            "identifier": "keys",
+                            "required": 0,
+                            "remember": 0,
+                            "multiple": false,
+                            "remember_roles": {
+                                "authenticated": "authenticated",
+                                "anonymous": 0,
+                                "4": 0,
+                                "3": 0
+                            }
+                        },
+                        "is_grouped": false,
+                        "group_info": {
+                            "label": "",
+                            "description": "",
+                            "identifier": "",
+                            "optional": true,
+                            "widget": "select",
+                            "multiple": false,
+                            "remember": 0,
+                            "default_group": "All",
+                            "default_group_multiple": [],
+                            "group_items": []
+                        },
+                        "remove_score": 0
+                    }
+                },
+                "sorts": {
+                    "created": {
+                        "id": "created",
+                        "table": "node",
+                        "field": "created",
+                        "relationship": "latest_release",
+                        "group_type": "group",
+                        "ui_name": "",
+                        "order": "DESC",
+                        "exposed": false,
+                        "expose": {
+                            "label": ""
+                        },
+                        "granularity": "second"
+                    }
+                },
+                "title": "Modules for Backdrop CMS",
+                "relationships": {
+                    "project_release_supported_versions": {
+                        "id": "project_release_supported_versions",
+                        "table": "node",
+                        "field": "project_release_supported_versions",
+                        "relationship": "none",
+                        "group_type": "group",
+                        "ui_name": "",
+                        "label": "supported",
+                        "required": 1
+                    },
+                    "latest_release": {
+                        "id": "latest_release",
+                        "table": "project_release_supported_versions",
+                        "field": "latest_release",
+                        "relationship": "project_release_supported_versions",
+                        "group_type": "group",
+                        "ui_name": "",
+                        "label": "latest",
+                        "required": 1
+                    },
+                    "project_releases": {
+                        "id": "project_releases",
+                        "table": "node",
+                        "field": "project_releases",
+                        "relationship": "latest_release",
+                        "group_type": "group",
+                        "ui_name": "",
+                        "label": "release info",
+                        "required": 0
+                    }
+                },
+                "row_options": {
+                    "default_field_elements": 0,
+                    "inline": [],
+                    "separator": " ",
+                    "hide_empty": 0
+                },
+                "use_ajax": false,
+                "header": {
+                    "area": {
+                        "id": "area",
+                        "table": "views",
+                        "field": "area",
+                        "relationship": "none",
+                        "group_type": "group",
+                        "ui_name": "",
+                        "label": "",
+                        "empty": 0,
+                        "content": "<h2>Modules can add to the set of available features on your site, or change the way existing features work.</h2>",
+                        "format": "filtered_html",
+                        "tokenize": 0
+                    }
+                },
+                "style_options": {
+                    "grouping": [],
+                    "row_class": "result",
+                    "default_row_class": 0,
+                    "row_class_special": 1,
+                    "type": "ol",
+                    "wrapper_class": "project-search__results-wrapper l-content-wrapper",
+                    "class": "project-search__results"
+                }
+            }
+        },
+        "page_1": {
+            "display_title": "Modules",
+            "display_plugin": "page",
+            "display_options": {
+                "query": {
+                    "type": "views_query",
+                    "options": []
+                },
+                "path": "modules",
+                "display_description": ""
+            }
+        },
+        "page_2": {
+            "display_title": "Themes",
+            "display_plugin": "page",
+            "display_options": {
+                "query": {
+                    "type": "views_query",
+                    "options": []
+                },
+                "path": "themes",
+                "display_description": "",
+                "filters": {
+                    "status": {
+                        "value": 1,
+                        "table": "node",
+                        "field": "status",
+                        "id": "status",
+                        "expose": {
+                            "operator": false
+                        },
+                        "group": 1
+                    },
+                    "type": {
+                        "id": "type",
+                        "table": "node",
+                        "field": "type",
+                        "relationship": "none",
+                        "group_type": "group",
+                        "ui_name": "",
+                        "operator": "in",
+                        "value": {
+                            "project_theme": "project_theme"
+                        },
+                        "group": "1",
+                        "exposed": false,
+                        "expose": {
+                            "operator_id": false,
+                            "label": "",
+                            "description": "",
+                            "use_operator": false,
+                            "operator": "",
+                            "identifier": "",
+                            "required": false,
+                            "remember": false,
+                            "multiple": false,
+                            "remember_roles": {
+                                "authenticated": "authenticated"
+                            },
+                            "reduce": false
+                        },
+                        "is_grouped": false,
+                        "group_info": {
+                            "label": "",
+                            "description": "",
+                            "identifier": "",
+                            "optional": true,
+                            "widget": "select",
+                            "multiple": false,
+                            "remember": 0,
+                            "default_group": "All",
+                            "default_group_multiple": [],
+                            "group_items": []
+                        }
+                    },
+                    "title": {
+                        "id": "title",
+                        "table": "node",
+                        "field": "title",
+                        "relationship": "none",
+                        "group_type": "group",
+                        "ui_name": "",
+                        "operator": "contains",
+                        "value": "",
+                        "group": "1",
+                        "exposed": true,
+                        "expose": {
+                            "operator_id": "title_op",
+                            "label": "",
+                            "description": "",
+                            "use_operator": 0,
+                            "operator": "title_op",
+                            "identifier": "title",
+                            "required": 0,
+                            "remember": 0,
+                            "multiple": false,
+                            "remember_roles": {
+                                "authenticated": "authenticated",
+                                "anonymous": 0,
+                                "4": 0,
+                                "3": 0
+                            }
+                        },
+                        "is_grouped": false,
+                        "group_info": {
+                            "label": "",
+                            "description": "",
+                            "identifier": "",
+                            "optional": true,
+                            "widget": "select",
+                            "multiple": false,
+                            "remember": 0,
+                            "default_group": "All",
+                            "default_group_multiple": [],
+                            "group_items": []
+                        }
+                    }
+                },
+                "defaults": {
+                    "filters": false,
+                    "filter_groups": false,
+                    "header": false,
+                    "title": false
+                },
+                "filter_groups": {
+                    "operator": "AND",
+                    "groups": {
+                        "1": "AND"
+                    }
+                },
+                "header": {
+                    "area": {
+                        "id": "area",
+                        "table": "views",
+                        "field": "area",
+                        "relationship": "none",
+                        "group_type": "group",
+                        "ui_name": "",
+                        "label": "",
+                        "empty": 0,
+                        "content": "<h2>Themes are skins for your site that allow you to change the look, feel, and general appearance.</h2>",
+                        "format": "filtered_html",
+                        "tokenize": 0
+                    }
+                },
+                "title": "Themes for Backdrop CMS"
+            }
+        },
+        "page_3": {
+            "display_title": "Layouts",
+            "display_plugin": "page",
+            "display_options": {
+                "query": {
+                    "type": "views_query",
+                    "options": []
+                },
+                "path": "layouts",
+                "display_description": "",
+                "filters": {
+                    "status": {
+                        "value": 1,
+                        "table": "node",
+                        "field": "status",
+                        "id": "status",
+                        "expose": {
+                            "operator": false
+                        },
+                        "group": 1
+                    },
+                    "type": {
+                        "id": "type",
+                        "table": "node",
+                        "field": "type",
+                        "relationship": "none",
+                        "group_type": "group",
+                        "ui_name": "",
+                        "operator": "in",
+                        "value": {
+                            "project_layout": "project_layout"
+                        },
+                        "group": "1",
+                        "exposed": false,
+                        "expose": {
+                            "operator_id": false,
+                            "label": "",
+                            "description": "",
+                            "use_operator": false,
+                            "operator": "",
+                            "identifier": "",
+                            "required": false,
+                            "remember": false,
+                            "multiple": false,
+                            "remember_roles": {
+                                "authenticated": "authenticated"
+                            },
+                            "reduce": false
+                        },
+                        "is_grouped": false,
+                        "group_info": {
+                            "label": "",
+                            "description": "",
+                            "identifier": "",
+                            "optional": true,
+                            "widget": "select",
+                            "multiple": false,
+                            "remember": 0,
+                            "default_group": "All",
+                            "default_group_multiple": [],
+                            "group_items": []
+                        }
+                    },
+                    "title": {
+                        "id": "title",
+                        "table": "node",
+                        "field": "title",
+                        "relationship": "none",
+                        "group_type": "group",
+                        "ui_name": "",
+                        "operator": "contains",
+                        "value": "",
+                        "group": "1",
+                        "exposed": true,
+                        "expose": {
+                            "operator_id": "title_op",
+                            "label": "",
+                            "description": "",
+                            "use_operator": 0,
+                            "operator": "title_op",
+                            "identifier": "title",
+                            "required": 0,
+                            "remember": 0,
+                            "multiple": false,
+                            "remember_roles": {
+                                "authenticated": "authenticated",
+                                "anonymous": 0,
+                                "4": 0,
+                                "3": 0
+                            }
+                        },
+                        "is_grouped": false,
+                        "group_info": {
+                            "label": "",
+                            "description": "",
+                            "identifier": "",
+                            "optional": true,
+                            "widget": "select",
+                            "multiple": false,
+                            "remember": 0,
+                            "default_group": "All",
+                            "default_group_multiple": [],
+                            "group_items": []
+                        }
+                    }
+                },
+                "defaults": {
+                    "filters": false,
+                    "filter_groups": false,
+                    "header": false,
+                    "title": false
+                },
+                "filter_groups": {
+                    "operator": "AND",
+                    "groups": {
+                        "1": "AND"
+                    }
+                },
+                "header": {
+                    "area": {
+                        "id": "area",
+                        "table": "views",
+                        "field": "area",
+                        "relationship": "none",
+                        "group_type": "group",
+                        "ui_name": "",
+                        "label": "",
+                        "empty": 0,
+                        "content": "<h2>Layouts divide pages on your site into different columns or regions where content can be placed.</h2>",
+                        "format": "filtered_html",
+                        "tokenize": 0
+                    }
+                },
+                "title": "Layouts for Backdrop CMS"
+            }
+        }
+    }
+}

--- a/config/dev-active/views.view.quotes.json
+++ b/config/dev-active/views.view.quotes.json
@@ -39,7 +39,7 @@
                     "default_row_class": 0,
                     "row_class_special": 0,
                     "type": "ul",
-                    "wrapper_class": "flexslider",
+                    "wrapper_class": "flexslider l-content-wrapper",
                     "class": "slides"
                 },
                 "row_plugin": "fields",

--- a/www/layouts/double_fixed/double-fixed.css
+++ b/www/layouts/double_fixed/double-fixed.css
@@ -29,15 +29,16 @@
   -moz-box-sizing: border-box;
   -webkit-box-sizing: border-box;
   box-sizing: border-box;
+  text-align: left;
 }
-.layout--double-fixed .l-content-inner {
+.layout--double-fixed .l-content-wrapper {
   text-align: left;
   max-width: 700px;
   margin: 0 auto;
-  padding: 0 15px;
+  padding: 0 25px;
 }
 @media all and (min-width: 851px) {
-  .layout--double-fixed .l-content-inner {
+  .layout--double-fixed .l-content-wrapper {
     padding: 0 35px;
   }
 }
@@ -68,19 +69,20 @@
   }
 
   /* Two Sidebars */
-  .layout--double-fixed.layout-both-sidebars .l-container {
-    padding-left: 460px;
+  .layout-both-sidebars .layout--double-fixed .l-container {
+    padding-left: 230px;
   }
-  [dir="rtl"] .layout--double-fixed.layout-both-sidebars .l-container {
+  [dir="rtl"] .layout-both-sidebars .layout--double-fixed .l-container {
     padding-left: 0;
-    padding-right: 460px;
+    padding-right: 230px;
   }
 
   /* One Sidebar */
-  .layout--double-fixed.layout-one-sidebar .l-container {
+  body {
     padding-left: 230px;
   }
-  [dir="rtl"] .layout--double-fixed.layout-one-sidebar .l-container {
+
+  [dir="rtl"] body {
     padding-left: 0;
     padding-right: 230px;
   }

--- a/www/layouts/double_fixed/layout--double-fixed.tpl.php
+++ b/www/layouts/double_fixed/layout--double-fixed.tpl.php
@@ -31,22 +31,23 @@
 
   <div class="l-container">
     <main class="l-content" role="main">
-      <div class="l-content-inner">
         <div class="l-content-top">
-        <a id="main-content"></a>
-          <?php print render($title_prefix); ?>
-          <?php if ($title): ?>
-            <h1 class="title" id="page-title">
-              <?php print $title; ?>
-            </h1>
-          <?php endif; ?>
-          <?php print render($title_suffix); ?>
+          <div class="l-content-wrapper">
+            <a id="main-content"></a>
+            <?php print render($title_prefix); ?>
+            <?php if ($title): ?>
+              <h1 class="title" id="page-title">
+                <?php print $title; ?>
+              </h1>
+            <?php endif; ?>
+            <?php print render($title_suffix); ?>
 
-          <?php print $content['content-top']; ?>
+            <?php print $content['content-top']; ?>
+          </div>
         </div>
 
         <?php if ($tabs): ?>
-          <div class="tabs">
+          <div class="tabs l-content-wrapper">
             <?php print $tabs; ?>
           </div>
         <?php endif; ?>

--- a/www/themes/borg/css/base.css
+++ b/www/themes/borg/css/base.css
@@ -17,7 +17,7 @@ body {
 
 p {
   font-size: 110%;
-  line-height: 140%;
+  line-height: 1.4;
   margin: 1em 0;
 }
 
@@ -25,8 +25,9 @@ a {
   color: #007CBA;
   text-decoration: none;
 }
+
 a:hover {
-  color: #007CBA:
+  color: #007CBA;
 }
 
 img {
@@ -42,7 +43,13 @@ h1 {
 h2 {
   margin: 1em 0;
   font-weight: 300; /* Light */
-  font-size: 42px;
+  font-size: 38px;
+}
+
+@media (min-width: 520px) {
+  h2 {
+    font-size: 42px;
+  }
 }
 
 h3 {
@@ -61,6 +68,7 @@ h4 {
 
 ul {
   margin: .75em 0;
+  padding-left: 2em;
 }
 li {
   margin: .5em 0;

--- a/www/themes/borg/css/components.css
+++ b/www/themes/borg/css/components.css
@@ -635,3 +635,163 @@ body.front .block-block-4 h2 {
   vertical-align: top;
   width: 29%;
 }
+
+/*******************************************************************************
+ * Default pager styles
+ ******************************************************************************/
+.view .item-list {
+   text-align: center;
+}
+
+.item-list .pager {
+   display: inline-block;
+   margin: 20px 0 0;
+   padding: 0;
+}
+
+.item-list .pager li {
+   position: relative;
+   display: block;
+   float: left;
+   min-width: 2em;
+   height: 2em;
+   margin: 0;
+   padding: 2px;
+   line-height: 2em;
+   font-weight: normal;
+  font-size: 1.3em;
+}
+
+.item-list .pager li a {
+   display: block;
+   min-width: 2em;
+   height: 2em;
+   color: #86898a;
+}
+.item-list .pager li a:hover,
+.item-list .pager li a:focus,
+.item-list .pager li a:active {
+  color: #007CBA;
+}
+.item-list .pager .pager-item {
+  display: none;
+}
+.item-list .pager .pager-current:before {
+  content: 'Page ';
+}
+@media (min-width: 580px) {
+  .item-list .pager .pager-item {
+    display: block;
+  }
+  .item-list .pager .pager-current:before {
+    content: '';
+  }
+}
+.pager-current:before,
+.pager-current + .pager-item:before,
+.pager-item + .pager-item:before {
+   content: '';
+}
+.pager-current:first-child:before {
+  display: none;
+}
+@media (min-width: 580px) {
+  .pager-current:before,
+  .pager-current + .pager-item:before,
+  .pager-item + .pager-item:before {
+     position: absolute;
+     left: 0;
+     top: 50%;
+     z-index: 1;
+     width: 0em;
+     height: 1.2em;
+     pointer-events: none;
+     -webkit-transform: translate(-0.05em, -50%) rotate(20deg);
+         -ms-transform: translate(-0.05em, -50%) rotate(20deg);
+             transform: translate(-0.05em, -50%) rotate(20deg);
+     border-left: 1px solid #86898a;
+  }
+}
+.pager-first a,
+.pager-previous a,
+.pager-next a,
+.pager-last a {
+   position: relative;
+   display: block;
+   width: 2em;
+   height: 2em;
+   text-indent: -9999em;
+   overflow: hidden;
+}
+.pager-first a:before,
+.pager-first a:after,
+.pager-previous a:before,
+.pager-previous a:after,
+.pager-next a:before,
+.pager-next a:after,
+.pager-last a:before,
+.pager-last a:after {
+   position: absolute;
+   top: 0;
+   left: 0;
+   content: '';
+   border: 0 solid #86898a;
+   width: .5em;
+   height: .5em;
+   -webkit-transform: translate(0.6em, 0.65em) rotate(45deg);
+       -ms-transform: translate(0.6em, 0.65em) rotate(45deg);
+           transform: translate(0.6em, 0.65em) rotate(45deg);
+}
+@media (min-width: 580px) {
+  .pager-first a:hover:before,
+  .pager-first a:hover:after,
+  .pager-previous a:hover:before,
+  .pager-previous a:hover:after,
+  .pager-next a:hover:before,
+  .pager-next a:hover:after,
+  .pager-last a:hover:before,
+  .pager-last a:hover:after {
+    border-color: #007CBA;
+  }
+}
+.pager-first a:before,
+.pager-first a:after {
+   border-width: 0 0 2px 2px;
+}
+.pager-first a:before {
+   left: 1px;
+}
+.pager-first a:after {
+   left: 7px;
+}
+.pager-previous a:before {
+   border-width: 0 0 2px 2px;
+}
+.pager-previous a:before {
+   left: 3px;
+}
+.pager-next a:before {
+   border-width: 2px 2px 0 0;
+}
+.pager-next a:before {
+   left: 0px;
+}
+.pager-last a:before,
+.pager-last a:after {
+   border-width: 2px 2px 0 0;
+}
+.pager-last a:before {
+   left: -5px;
+}
+.pager-last a:after {
+   left: 1px;
+}
+
+
+/*******************************************************************************
+ * Project releases view
+ ******************************************************************************/
+.view-project-releases-by-project .view-empty {
+  margin: 1em 0;
+  font-size: 1.2em;
+}

--- a/www/themes/borg/css/layout.css
+++ b/www/themes/borg/css/layout.css
@@ -5,8 +5,13 @@
  * etc. should be in the layouts/double_fixed/double-fixed.css file!
  ******************************************************************************/
 #page-title {
-  font-size: 64px;
+  font-size: 45px;
   letter-spacing: -.04em;
+}
+@media (min-width: 520px) {
+  #page-title {
+    font-size: 64px;
+  }
 }
 @media (min-width: 1024px) {
   #page-title {
@@ -24,27 +29,35 @@ body.front #page-title {
  * Main content.
  ******************************************************************************/
 main {
-  padding-top: 70px;
+  position: relative;
+}
+main:before {
+  content: 'Backdrop';
+  /* Aspect ratio hack: http://codepen.io/wesruv/full/hindu */
+  display: block;
+  width: 95%;
+  height: 0;
+  padding: 23% 0 0;
+  margin: 25px auto 0;
   background-image: url('../images/Backdrop-Logo-Horizontal.png');
   background-image: linear-gradient(transparent, transparent), url('../images/Backdrop-Logo-Horizontal.svg');
   background-position: top center;
   background-repeat: no-repeat;
-  background-size: 80%;
+  background-size: 100% auto;
+  text-indent: -9999em;
+  overflow: hidden;
+  transition: width 0.2s ease-out;
+  will-change: width;
 }
 @media (min-width: 520px) {
-  main {
-    padding-top: 100px;
-  }
-}
-@media (min-width: 700px) {
-  main {
-    padding-top: 160px;
+  main:before {
+    width: 80%;
   }
 }
 @media (min-width: 851px) {
-  main {
-    background-image: none;
-    padding-top: 0;
+  main:before {
+    display: none;
+    content: '';
   }
 }
 
@@ -95,7 +108,7 @@ main {
   transition: padding 0.3s ease;
 }
 .drawer-closed .l-drawer {
-  left: -2px !important;
+  left: -2px;
 }
 .l-drawer span {
   display: block;

--- a/www/themes/borg/css/project-search.css
+++ b/www/themes/borg/css/project-search.css
@@ -1,0 +1,191 @@
+h1 {
+  margin-bottom: 10px;
+}
+
+.view-modules h2 {
+  margin-top: 0;
+  color: #929597;
+  font-size: 30px;
+}
+
+.views-exposed-widgets {
+  width: 100%;
+  margin: 0 0 3em;
+}
+
+.views-exposed-form .views-widget-filter-keys,
+.views-exposed-form .views-widget-filter-title,
+.views-exposed-form .views-submit-button {
+  height: 2em;
+  padding: 0;
+  float: left;
+  font-size: 25px;
+  line-height: 1.5;
+}
+
+.views-exposed-form .views-widget-filter-keys,
+.views-exposed-form .views-widget-filter-title {
+  width: calc(100% - 2.3em);
+}
+
+.views-exposed-form .views-submit-button {
+  width: 2.3em;
+}
+
+.views-exposed-form .form-text,
+.views-exposed-form .form-submit {
+  display: block;
+  border: 2px solid #000;
+  margin: 0;
+  font-size: inherit;
+}
+
+.views-exposed-form .form-text:hover,
+.views-exposed-form .form-submit:hover {
+  border-color: #000;
+}
+
+.views-exposed-form .form-text {
+  width: 100%;
+  height: 2em;
+  padding: 0.3em 0 0.3em .6em;
+  border-right: 0;
+  border-radius: 0;
+  font-weight: 300;
+}
+
+.views-exposed-form .form-submit {
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  text-indent: -9999em;
+  border-radius: 0;
+  background: #cfde56;
+}
+
+.views-exposed-form .form-submit:hover,
+.views-exposed-form .form-submit:focus,
+.views-exposed-form .form-submit:active {
+  background: #c7cc00;
+}
+
+
+/**
+ * Mag glass icon
+ */
+.views-exposed-form .views-submit-button {
+  position: relative;
+}
+
+.views-exposed-form .views-submit-button:before,
+.views-exposed-form .views-submit-button:after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  z-index: 5;
+  pointer-events: none;
+}
+
+.views-exposed-form .views-submit-button:before {
+  width: 0.5em;
+  height: 0.5em;
+  border: 3px solid #fff;
+  border-radius: 50%;
+  -webkit-transform: translate(-0.5em, -0.5em);
+  -ms-transform: translate(-0.5em, -0.5em);
+  transform: translate(-0.5em, -0.5em);
+}
+
+.views-exposed-form .views-submit-button:after {
+  width: 0.45em;
+  height: 3px;
+  border-radius: 0 2px 2px 0;
+  -webkit-transform: translate(0.05em, 0.18em) rotate(45deg);
+  -ms-transform: translate(0.05em, 0.18em) rotate(45deg);
+  transform: translate(0.05em, 0.18em) rotate(45deg);
+  background: #fff;
+}
+
+/**
+ * Search results styling
+ */
+.view-modules .view-content {
+  border: 1px solid #d4d6d6;
+  border-width: 1px 0;
+  background: #fafafa;
+}
+
+.project-search--results {
+  margin: 0;
+  padding: 0;
+  line-height: 1.4;
+  list-style: none;
+}
+
+.project-search--results,
+.project-search--results p {
+  font-size: 16px;
+  line-height: 1.4;
+}
+
+.result {
+  padding: 28px 0;
+  border-bottom: 1px solid #d4d4d6;
+}
+
+.last.result {
+  border-bottom: 0;
+}
+
+.result h3 {
+  margin: 0;
+  font-weight: 600;
+  font-size: 27px;
+}
+
+.result h3 a {
+  color: #000;
+}
+
+.result__description {
+  margin: 0 0 1em;
+  color: #86898a;
+}
+
+.result__description p {
+  margin: 0 0 0.5em;
+}
+
+.result__info {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.result__info li {
+  margin: 0;
+}
+
+.result__info a {
+  color: #00a1d3;
+}
+
+.result__version,
+.result__version:before,
+.result__version:after {
+  display: inline-block;
+  padding: 0 0 0 0.4em;
+  font-size: 0.9em;
+  color: #86898a;
+}
+
+.result__version:before {
+  content: '(';
+  padding: 0 0.1em 0 0;
+}
+
+.result__version:after {
+  content: ')';
+  padding: 0 0 0 0.1em;
+}

--- a/www/themes/borg/css/project-styles.css
+++ b/www/themes/borg/css/project-styles.css
@@ -1,0 +1,74 @@
+ /* @todo Temporary styles until final design is implemented */
+.node-project-release h2,
+.view-project-release-download-table .view-header,
+.view-project-release-download-table th,
+.node-project-release ul.links.inline {
+  display: none;
+}
+
+.node-project-release .content h2 {
+  display: block;
+}
+/* End temp styles */
+
+.node-project-module h2,
+.node-project-theme h2,
+.node-project-layout h2,
+.node-project-release .form-item label{
+  font-size: 1em;
+  margin: 2em 0 1em;
+  padding: .8em 0 0;
+  border-top: 1px solid #d4d6d6;
+  text-transform: uppercase;
+  font-weight: 600;
+}
+
+.view-project-release-download-table .view-content {
+  font-size: 1.3em;
+}
+
+.view-project-release-download-table th {
+  font-weight: 400;
+  font-size: .8em;
+}
+
+.view-project-release-download-table th,
+.view-project-release-download-table td {
+  padding: 0 .8em .5em 0;
+  vertical-align: bottom;
+}
+
+@media (min-width: 520px) {
+  .view-project-release-download-table td {
+    padding: 0 2em .5em 0;
+  }
+}
+
+.view-project-release-download-table .recommended td:first-child a {
+  display: inline-block;
+  font-size: 1.4em;
+  margin: 0 .2em 0 0;
+}
+
+.view-project-release-download-table .recommended td:first-child a:after {
+  content: "\f0ab";
+  font-family: 'FontAwesome';
+  display: inline-block;
+  padding: 0 0 0 .2em;
+}
+
+/* This should add a headline to docs that don't have one */
+.field-name-body .field-item > p:first-child:before {
+  content: 'Documentation';
+  display: block;
+  font-size: 1em;
+  margin: 2em 0 1em;
+  padding: .8em 0 0;
+  border-top: 1px solid #d4d6d6;
+  text-transform: uppercase;
+  font-weight: 600;
+}
+
+.node-project-release .form-item {
+  font-size: 1.3em;
+}

--- a/www/themes/borg/js/borg.js
+++ b/www/themes/borg/js/borg.js
@@ -9,7 +9,7 @@
     $defaultActiveLink = $('.block-system-main-menu li.active').first();
     $menu = $('.block-system-main-menu ul.menu');
     $drawer = $('.l-drawer');
-    $layoutWrapper = $('.layout--double-fixed');
+    $layoutWrapper = $('body');
 
     // Bind to the handbook link to open/close the drawer.
     $('.block-system-main-menu a[href$="/handbook"]').click(function(e) {

--- a/www/themes/borg/template.php
+++ b/www/themes/borg/template.php
@@ -11,7 +11,7 @@
 /**
  * Prepares variables for page.tpl.php
  */
-function borg_preprocess_page() {
+function borg_preprocess_page(&$variables) {
   // Add the Source Sans Pro font.
   backdrop_add_css('https://fonts.googleapis.com/css?family=Source+Sans+Pro:200,300,400,600,700', array('type' => 'external'));
   // Add FontAwesome.
@@ -28,15 +28,11 @@ $(window).load(function() {
 });";
     backdrop_add_js($script, array('type' => 'inline'));
   }
-}
 
-/**
- * Prepares variables for layout.tpl.php
- */
-function borg_preprocess_layout__double_fixed(&$variables) {
   $node = menu_get_object();
   if (isset($node) && isset($node->type) && $node->type === 'book') {
     $variables['classes'][] = 'drawer-open';
+    $variables['classes'][] = 'layout-both-sidebars';
   }
   else {
     $variables['classes'][] = 'drawer-closed';
@@ -44,6 +40,61 @@ function borg_preprocess_layout__double_fixed(&$variables) {
     if ($array_key !== FALSE) {
       $variables['classes'][$array_key] = 'layout-one-sidebar';
     }
+  }
+}
+
+/**
+ * Preprocess views_view
+ */
+function borg_preprocess_views_view(&$variables) {
+  $path = backdrop_get_path('theme', 'borg');
+  if($variables['name'] == 'modules') {
+    backdrop_add_css($path . '/css/project-search.css');
+  }
+}
+
+/**
+ * Preprocess views exposed forms
+ */
+function borg_preprocess_views_exposed_form(&$variables) {
+  if(substr($variables['form']['#id'], 0, 26) == 'views-exposed-form-modules'){
+    // Update search field
+    $search_field_key = '';
+    $search_type = '';
+    if (!empty($variables['form']['title'])){
+      $search_field_key = 'title';
+      if($variables['form']['#id'] == 'views-exposed-form-modules-page-2') {
+        $search_type = 'themes';
+      }
+      elseif ($variables['form']['#id'] == 'views-exposed-form-modules-page-3') {
+        $search_type = 'layouts';
+      }
+    }
+    elseif (!empty($variables['form']['keys'])){
+      $search_field_key = 'keys';
+      $search_type = 'modules';
+    }
+
+    if (!empty($search_field_key)){
+      // Boo divitis
+      unset($variables['form'][$search_field_key]['#theme_wrappers']);
+      // Add placeholder text
+      $variables['form'][$search_field_key]['#attributes']['placeholder'] = t('Search '. $search_type .'...');
+      // Re-render field
+      $variables['widgets']['filter-'. $search_field_key]->widget = render($variables['form'][$search_field_key]);
+    }
+  }
+}
+
+/**
+ * Prepare variables for node template
+ */
+function borg_preprocess_node(&$variables){
+  $path = backdrop_get_path('theme', 'borg');
+  if (substr($variables['type'], 0, 8) == 'project_'){
+    $variables['content']['project_release_downloads']['#prefix'] = '<h2>' . t('Downloads')  . '</h2>';
+    $variables['content']['project_release_downloads']['#weight'] = -10;
+    backdrop_add_css($path . '/css/project-styles.css');
   }
 }
 

--- a/www/themes/borg/templates/views-exposed-form.tpl.php
+++ b/www/themes/borg/templates/views-exposed-form.tpl.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * @file
+ * This template handles the layout of the views exposed filter form.
+ *
+ * Variables available:
+ * - $widgets: An array of exposed form widgets. Each widget contains:
+ * - $widget->label: The visible label to print. May be optional.
+ * - $widget->operator: The operator for the widget. May be optional.
+ * - $widget->widget: The widget itself.
+ * - $sort_by: The select box to sort the view using an exposed form.
+ * - $sort_order: The select box with the ASC, DESC options to define order. May be optional.
+ * - $items_per_page: The select box with the available items per page. May be optional.
+ * - $offset: A textfield to define the offset of the view. May be optional.
+ * - $reset_button: A button to reset the exposed filter applied. May be optional.
+ * - $button: The submit button for the form.
+ *
+ * @ingroup views_templates
+ */
+?>
+<?php if (!empty($q)): ?>
+  <?php
+    // This ensures that, if clean URLs are off, the 'q' is added first so that
+    // it shows up first in the URL.
+    print $q;
+  ?>
+<?php endif; ?>
+<div class="views-exposed-widgets clearfix">
+  <?php foreach ($widgets as $id => $widget): ?>
+    <div id="<?php print $widget->id; ?>-wrapper" class="views-exposed-widget views-widget-<?php print $id; ?>">
+      <?php if (!empty($widget->label)): ?>
+        <label for="<?php print $widget->id; ?>">
+          <?php print $widget->label; ?>
+        </label>
+      <?php endif; ?>
+      <?php if (!empty($widget->operator)): ?>
+        <div class="views-operator">
+          <?php print $widget->operator; ?>
+        </div>
+      <?php endif; ?>
+        <?php print $widget->widget; ?>
+      <?php if (!empty($widget->description)): ?>
+        <div class="description">
+          <?php print $widget->description; ?>
+        </div>
+      <?php endif; ?>
+    </div>
+  <?php endforeach; ?>
+  <?php if (!empty($sort_by)): ?>
+    <div class="views-exposed-widget views-widget-sort-by">
+      <?php print $sort_by; ?>
+    </div>
+    <div class="views-exposed-widget views-widget-sort-order">
+      <?php print $sort_order; ?>
+    </div>
+  <?php endif; ?>
+  <?php if (!empty($items_per_page)): ?>
+    <div class="views-exposed-widget views-widget-per-page">
+      <?php print $items_per_page; ?>
+    </div>
+  <?php endif; ?>
+  <?php if (!empty($offset)): ?>
+    <div class="views-exposed-widget views-widget-offset">
+      <?php print $offset; ?>
+    </div>
+  <?php endif; ?>
+  <div class="views-exposed-widget views-submit-button">
+    <?php print $button; ?>
+  </div>
+  <?php if (!empty($reset_button)): ?>
+    <div class="views-exposed-widget views-reset-button">
+      <?php print $reset_button; ?>
+    </div>
+  <?php endif; ?>
+</div>

--- a/www/themes/borg/templates/views-view--modules.tpl.php
+++ b/www/themes/borg/templates/views-view--modules.tpl.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * @file
+ * Main view template.
+ *
+ * Variables available:
+ * - $classes: An array of classes determined in
+ *   template_preprocess_views_view(). Default classes are:
+ *     .view
+ *     .view-[css_name]
+ *     .view-id-[view_name]
+ *     .view-display-id-[display_name]
+ *     .view-dom-id-[dom_id]
+ * - $css_name: A css-safe version of the view name.
+ * - $css_class: The user-specified classes names, if any
+ * - $header: The view header
+ * - $footer: The view footer
+ * - $rows: The results of the view query, if any
+ * - $empty: The empty text to display if the view is empty
+ * - $pager: The pager next/prev links to display, if any
+ * - $exposed: Exposed widget form/info to display
+ * - $feed_icon: Feed icon to display, if any
+ * - $more: A link to view more, if any
+ *
+ * @ingroup views_templates
+ */
+?>
+<div class="<?php print implode(' ', $classes); ?>">
+  <?php print render($title_prefix); ?>
+  <?php print render($title_suffix); ?>
+  <?php if ($header || $title): ?>
+    <div class="view-header l-content-wrapper">
+      <?php if ($title): ?>
+        <?php print $title; ?>
+      <?php endif; ?>
+      <?php print $header; ?>
+    </div>
+  <?php endif; ?>
+
+  <?php if ($exposed): ?>
+    <div class="view-filters l-content-wrapper">
+      <?php print $exposed; ?>
+    </div>
+  <?php endif; ?>
+
+  <?php if ($attachment_before): ?>
+    <div class="attachment attachment-before">
+      <?php print $attachment_before; ?>
+    </div>
+  <?php endif; ?>
+
+  <?php if ($rows): ?>
+    <div class="view-content">
+      <?php print (is_array($rows)) ? backdrop_render($rows) : $rows; ?>
+    </div>
+  <?php elseif ($empty): ?>
+    <div class="view-empty">
+      <?php print $empty; ?>
+    </div>
+  <?php endif; ?>
+
+  <?php if ($pager): ?>
+    <?php print $pager; ?>
+  <?php endif; ?>
+
+  <?php if ($attachment_after): ?>
+    <div class="attachment attachment-after">
+      <?php print $attachment_after; ?>
+    </div>
+  <?php endif; ?>
+
+  <?php if ($more): ?>
+    <?php print $more; ?>
+  <?php endif; ?>
+
+  <?php if ($footer): ?>
+    <div class="view-footer">
+      <?php print $footer; ?>
+    </div>
+  <?php endif; ?>
+
+  <?php if ($feed_icon): ?>
+    <div class="feed-icon">
+      <?php print $feed_icon; ?>
+    </div>
+  <?php endif; ?>
+
+</div><?php /* class view */ ?>

--- a/www/themes/borg/templates/views-view-fields--modules.tpl.php
+++ b/www/themes/borg/templates/views-view-fields--modules.tpl.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @file
+ * Custom template for Backdrop Extensions Search Results
+ */
+?>
+
+<?php print $fields['title']->content; ?>
+<?php if(!empty($fields['body']->content)): ?>
+<div class="result__description">
+  <?php print $fields['body']->content; ?>
+</div>
+<?php endif; ?>
+<ul class="result__info">
+  <li class="result__download">
+    <?php print $fields['version']->content; ?>
+    <?php if(!empty($fields['download_size']->content)): ?>
+      <span class="result__version"><?php print $fields['download_size']->content; ?></span>
+    <?php endif; ?>
+  </li>
+  <li class="result__more">
+    <?php print $fields['view_node']->content; ?>
+  </li>
+</ul>


### PR DESCRIPTION
Here's a video walking through the changes:
https://drive.google.com/file/d/0BzY54DXqV6bNdGxhcW1FZmFNX00/view?usp=sharing

Added layouts for modules, layouts, and themes, they're all the same... not sure if there's a good way to use one layout?
Added views config, which is slightly modified from what was given to me
Added interim styles for project pages, until we get the content spit out so it can be styled like the design
Added a utility class 'l-content-wrapper' which is used to contain content
* Normally this would be put on the outer wrapper of a block, but if a block has a bg color that should span the width of the page the class should go on an inner element
Reworked how the menu flies out of the side, added margin to the body instead of an outer div
* This was to make sure all content will be in the viewable area (selfishly my krumo output was hiding behind the drawer)
Changed the way the Backdrop logo is added at mobile to prevent content overlapping
Fixed misc. bugs that were happening at smaller screensizes by adding extra media query styles that maintained the same appearance at desktop