### PR TITLE
Logo will be in the top right whether or not image loads

### DIFF
--- a/www/modules/custom/borg_blocks/borg_blocks.module
+++ b/www/modules/custom/borg_blocks/borg_blocks.module
@@ -30,7 +30,7 @@ function borg_blocks_block_view($delta = '', $settings = array(), $contexts = ar
     case 'branding':
       $uri = backdrop_get_path('module', 'borg_blocks') . '/images/logo.png';
       $image = theme('image', array('uri' => $uri, 'alt' => t('Backdrop CMS Logo')));
-      $options = array('html' => TRUE, 'attributes' => array('class' => 'logo', 'title' => t('Backdrop CMS Home')));
+      $options = array('html' => TRUE, 'attributes' => array('class' => array('logo', 'backdrop-mark'), 'title' => t('Backdrop CMS Home')));
       $output = l($image, '', $options);
       // Change the class for the text link.
       $options['attributes']['class'] = array('site-name');

--- a/www/themes/borg/css/patterns.css
+++ b/www/themes/borg/css/patterns.css
@@ -81,3 +81,48 @@ a.button span {
   font-weight: 400;
   color: #969595;
 }
+
+/*******************************************************************************
+ * Backdrop mark drawn with CSS
+ * Is fluid, defaults to 100% width, but can be changed and the graphic will scale
+ * Text can be added inside element for screenreaders (e.g. Backdrop)
+ ******************************************************************************/
+.backdrop-mark {
+  position: relative;
+  display: block;
+  text-indent: -9999em;
+  overflow: hidden;
+  width: 100%;
+  height: 0;
+  padding: 100% 0 0;
+  background: #000;
+}
+.backdrop-mark:before, .backdrop-mark:after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  display: block;
+  width: 50%;
+  height: 50%;
+}
+.backdrop-mark:before {
+  z-index: 1;
+  background: #fff;
+}
+.backdrop-mark:after {
+  z-index: 2;
+  -webkit-transform: rotate(45deg) scaleY(1.5);
+      -ms-transform: rotate(45deg) scaleY(1.5);
+          transform: rotate(45deg) scaleY(1.5);
+  -webkit-transform-origin: bottom left;
+      -ms-transform-origin: bottom left;
+          transform-origin: bottom left;
+  background: #000;
+}
+.backdrop-mark img {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 3;
+}


### PR DESCRIPTION
Drew logo with CSS, which will be covered with the image when it loads.
This prevents layout shifting when the logo loads AND the exact same visual is there without the image

Having an actual image there is good for sharing and human purposes. Otherwise I'd remove it entirely :stuck_out_tongue: 