### PR TITLE
Added text on empty links found by WAVE accessibility toolbar

### DIFF
--- a/www/themes/borg/template.php
+++ b/www/themes/borg/template.php
@@ -139,15 +139,15 @@ function borg_menu_link(array $variables) {
  */
 function borg_on_the_web_image($variables) {
   if ($variables['service'] == 'twitter') {
-    return '<i class="fa fa-twitter-square"></i>';
+    return '<i class="fa fa-twitter-square"></i><span class="element-invisible">Backdrop CMS on Twitter</span>';
   }
   if ($variables['service'] == 'facebook') {
-    return '<i class="fa fa-facebook-square"></i>';
+    return '<i class="fa fa-facebook-square"></i><span class="element-invisible">Backdrop CMS on Facebook</span>';
   }
   if ($variables['service'] == 'google') {
-    return '<i class="fa fa-google-plus-square"></i>';
+    return '<i class="fa fa-google-plus-square"></i><span class="element-invisible">Backdrop CMS on Google Plus</span>';
   }
   if ($variables['service'] == 'youtube') {
-    return '<i class="fa fa-youtube-square"></i>';
+    return '<i class="fa fa-youtube-square"></i><span class="element-invisible">Backdrop CMS on YouTube</span>';
   }
 }


### PR DESCRIPTION
@quicksketch there's also an issue with the content inside the mailchimp block, there isn't a label for the e-mail field.

I just added this above the input in the markup:
`<label class="element-invisible" for="mce-EMAIL">Email</label>`