### PR TITLE
Issue #448: Add a new link field to the "Documentation" content type

### DIFF
--- a/www/themes/borg/css/components-nodes.css
+++ b/www/themes/borg/css/components-nodes.css
@@ -128,11 +128,9 @@ label.github-clone-label {
 /*******************************************************************************
  * Node: Documentation - status/level fields
  ******************************************************************************/
-.field-name-field-docs-level {
+.field-name-field-docs-level,
+.field-name-field-docs-status,
+.field-name-field-docs-source {
   padding: 15px 15px 5px 15px;
-  background-color: #f7f7f7;
-}
-.field-name-field-docs-status {
-  padding: 5px 15px 15px 15px;
   background-color: #f7f7f7;
 }


### PR DESCRIPTION
https://github.com/backdrop-ops/backdropcms.org/issues/448