### PR TITLE
Backdrop Issue #1992: Proof of concept for adding package signing support.

### DIFF
--- a/www/core/misc/public_keys/backdropcmsorg_primary.key
+++ b/www/core/misc/public_keys/backdropcmsorg_primary.key
@@ -1,0 +1,1 @@
+Primay public key goes here.

--- a/www/core/misc/public_keys/backdropcmsorg_secondary.key
+++ b/www/core/misc/public_keys/backdropcmsorg_secondary.key
@@ -1,0 +1,1 @@
+Backup public key goes here.

--- a/www/core/modules/installer/installer.browser.inc
+++ b/www/core/modules/installer/installer.browser.inc
@@ -308,7 +308,7 @@ function _installer_browser_batch_install_release($release_name, $project, &$con
 
   module_load_include('inc', 'installer', 'installer.manager');
   $url = file_create_url($release['download_link']);
-  $result = installer_manager_download_project($url, TRUE);
+  $result = installer_manager_download_project($url, TRUE, $release);
 
   if ($result['success']) {
     $context['results']['successes'][] = t('Successfully installed %project.', array('%project' => $project['title']));

--- a/www/core/modules/installer/installer.manager.inc
+++ b/www/core/modules/installer/installer.manager.inc
@@ -779,6 +779,11 @@ function installer_manager_install_form_submit($form, &$form_state) {
  * @param string $is_installer
  *   Whether the project is being installed via the Project Installer UI.
  *
+ * @param array $release_info
+ *   Information about the release, as provided by the project release history.
+ *   If installed via a direct upload or URL without a history, this value will
+ *   be NULL. Including the release info adds MD5 and signature validation.
+ *
  * @return array
  *   An associative array with keys:
  *   - 'success': whether the update was successful
@@ -789,7 +794,7 @@ function installer_manager_install_form_submit($form, &$form_state) {
  * @see system_authorized_init()
  * @see system_authorized_get_url()
  */
-function installer_manager_download_project($url, $is_installer = FALSE) {
+function installer_manager_download_project($url, $is_installer = FALSE, $release = NULL) {
   if ($url) {
     $local_cache = installer_manager_file_get($url);
     if (!$local_cache) {
@@ -814,6 +819,33 @@ function installer_manager_download_project($url, $is_installer = FALSE) {
   }
   else {
     $local_cache = NULL;
+  }
+
+  // Validate MD5 and Signature if present.
+  if ($release) {
+    $md5 = $release['download_md5'];
+    if ($md5 !== md5_file($local_cache)) {
+      return array(
+        'success' => FALSE,
+        'message' => t('The contents of the downloaded project do not match (MD5 mismatch).'),
+      );
+    }
+
+    // @todo: This could be a lot fancier. Such as scanning the entire directory
+    // for more keys, searching alternative key locations, etc.
+    $signature = base64_decode($release['download_signature']);
+    $primary_public_key = file_get_contents(BACKDROP_ROOT . '/core/misc/public_keys/backdropcmsorg_primary.key');
+    if (!sodium_crypto_sign_verify_detached($signature, $md5, $primary_public_key)) {
+      // Try the backup key in the event the primary key has been revoked and
+      // the signature used the backup key instead.
+      $secondary_public_key = file_get_contents(BACKDROP_ROOT . '/core/misc/public_keys/backdropcmsorg_secondary.key');
+      if (!sodium_crypto_sign_verify_detached($signature, $md5, $secondary_public_key)) {
+        return array(
+          'success' => FALSE,
+          'message' => t('The package signature could not be validated.'),
+        );
+      }
+    }
   }
 
   // Try to extract it.

--- a/www/modules/contrib/project/project_github/project_github.api.php
+++ b/www/modules/contrib/project/project_github/project_github.api.php
@@ -62,7 +62,7 @@ function hook_github_project_validate(Node $project_node, array &$errors, array 
  *   No return value.
  */
 function hook_github_project_validate_release(Node $release_node, array &$errors, array $payload) {
-  $project_node = node_load($release_node->project['release_nid']);
+  $project_node = node_load($release_node->project_release['release_nid']);
   if ($project_node->type === 'project_module') {
     $release_node->type = 'module_release';
   }

--- a/www/modules/contrib/project/project_release/project_release.cron.inc
+++ b/www/modules/contrib/project/project_release/project_release.cron.inc
@@ -130,15 +130,14 @@ function project_release_history_generate_project_xml(Node $project_node, $versi
         $release_link = !empty($release_node->project_release['release_link']) ? $release_node->project_release['release_link'] : url('node/' . $release_node->nid, array('absolute' => TRUE));
         $output .= '  <release_link>' . check_plain($release_link) . "</release_link>\n";
         $output .= '  <download_link>' . check_plain($release_node->project_release['download_link']) . "</download_link>\n";
+        $output .= '  <download_md5>' . check_plain($release_node->project_release['download_md5']) . "</download_md5>\n";
+        $output .= '  <download_signature>' . check_plain($release_node->project_release['download_signature']) . "</download_signature>\n";
       }
       else {
         $output .= "  <status>unpublished</status>\n";
       }
       // We want to include the rest of these regardless of the status.
       $output .= '  <date>' . check_plain($release_node->created) . "</date>\n";
-      // We no longer provide an MD5 hash like Drupal 7 did. Update module
-      // never used this value though, so restoring it provides little value.
-      //$output .= '  <mdhash>'  . check_plain($release->download_md5) . "</mdhash>\n";
       $output .= '  <filesize>' . check_plain($release_node->project_release['download_size']) . "</filesize>\n";
 
       $security_update = $release_node->project_release['security_update'];

--- a/www/modules/contrib/project/project_release/project_release.install
+++ b/www/modules/contrib/project/project_release/project_release.install
@@ -90,6 +90,16 @@ function project_release_schema() {
         'description' => 'URL to the release download archive.',
         'type' => 'text',
       ),
+      'download_md5' => array(
+        'description' => 'MD5 value of the download archive file.',
+        'type' => 'varchar',
+        'length' => 32,
+        'not null' => FALSE,
+      ),
+      'download_signature' => array(
+        'description' => 'Base64 encoded signature for the download archive.',
+        'type' => 'text',
+      ),
       'download_size' => array(
         'description' => 'The size of the download archive, in bytes.',
         'type' => 'int',
@@ -264,4 +274,27 @@ function project_release_uninstall() {
  */
 function project_release_update_last_removed() {
   return 7015;
+}
+
+/**
+ * Adds a column for Download Archive MD5 value.
+ */
+function project_release_update_1100() {
+  if (!db_field_exists('project_release', 'download_md5')) {
+    $download_md5_spec = array(
+      'description' => 'MD5 value of the download archive file.',
+      'type' => 'varchar',
+      'length' => 32,
+      'not null' => FALSE,
+    );
+    db_add_field('project_release', 'download_md5', $download_md5_spec);
+  }
+
+  if (!db_field_exists('project_release', 'download_signature')) {
+    $download_signature_spec = array(
+      'description' => 'Base64 encoded signature for the download archive.',
+      'type' => 'text',
+    );
+    db_add_field('project_release', 'download_signature', $download_signature_spec);
+  }
 }

--- a/www/modules/contrib/project/project_release/project_release.module
+++ b/www/modules/contrib/project/project_release/project_release.module
@@ -483,10 +483,24 @@ function project_release_form_node_form_alter(&$form, &$form_state) {
     );
     $form['project_release']['download_link'] = array(
       '#type' => 'url',
-      '#title' => t('Download link'),
+      '#title' => t('Download link URL'),
       '#default_value' => $node->project_release['download_link'],
       '#description' => t('The URL to an archive containing this release.'),
       '#required' => TRUE,
+    );
+    $form['project_release']['download_md5'] = array(
+      '#type' => 'item',
+      '#title' => t('Download MD5'),
+      '#markup' => $node->project_release['download_md5'],
+      '#description' => t('MD5 value of the release archive.'),
+      '#access' => !empty($node->project_release['download_md5']),
+    );
+    $form['project_release']['download_signature'] = array(
+      '#type' => 'item',
+      '#title' => t('Download signature'),
+      '#markup' => $node->project_release['download_signature'],
+      '#description' => t('The base64 encoded signature for the release archive. Must be created by the packaging script.'),
+      '#access' => !empty($node->project_release['download_signature']),
     );
     $form['project_release']['release_link'] = array(
       '#type' => 'url',
@@ -667,15 +681,17 @@ function _project_release_node_save(Node $node) {
   if (project_release_node_is_release($node)) {
     // Determine the download file size if not provided.
     $is_new = empty($node->original);
-    $update_download_size = FALSE;
-    if (is_null($node->project_release['download_size']) || $node->project_release['download_size'] === '') {
-      $update_download_size = TRUE;
+    $update_download_info = FALSE;
+    if ((is_null($node->project_release['download_size']) || $node->project_release['download_size'] === '') ||
+        (is_null($node->project_release['download_md5']) || $node->project_release['download_md5'] === '')) {
+      $update_download_info = TRUE;
     }
     if (!$is_new && $node->original->project_release['download_link'] !== $node->project_release['download_link']) {
-      $update_download_size = TRUE;
+      $update_download_info = TRUE;
     }
-    if ($update_download_size) {
+    if ($update_download_info) {
       $node->project_release['download_size'] = project_release_get_download_size($node->project_release['download_link']);
+      $node->project_release['download_md5'] = project_release_get_download_md5($node->project_release['download_link']);
     }
 
     // Write the project release record to the database.
@@ -840,6 +856,21 @@ function project_release_get_download_size($download_link) {
     return (int) $result->headers['content-length'];
   }
   return 0;
+}
+
+/**
+ * Perform an HTTP request to get a file from a URL and return its MD5 hash.
+ *
+ * @return string
+ *   The MD5 hash of the file archive at the provided URL.
+ */
+function project_release_get_download_md5($download_link) {
+  $md5_list = &backdrop_static(__FUNCTION__, array());
+  if (!isset($md5_list[$download_link])) {
+    $result = backdrop_http_request($download_link);
+    $md5_list[$download_link] = isset($result->data) ? md5($result->data) : FALSE;
+  }
+  return $md5_list[$download_link];
 }
 
 /**

--- a/www/modules/custom/borg_github/borg_github.module
+++ b/www/modules/custom/borg_github/borg_github.module
@@ -116,3 +116,21 @@ function borg_github_github_project_validate(Node $project_node, array &$errors,
     }
   }
 }
+
+/**
+ * Implements hook_github_project_validate_release().
+ */
+function borg_github_github_project_validate_release(Node $release_node, array &$errors, array $payload) {
+  // Add a digital signature to the package on saving.
+  if ($release_node->project_release['download_link'] && empty($release_node->project_release['download_signature'])) {
+    $md5 = project_release_get_download_md5($release_node->project_release['download_link']);
+
+    // @todo: Replace with actual method for creating signature.
+    $secret_key = file_get_contents('/secret/key/directory/secret.key');
+    $signature = sodium_crypto_sign_detached($md5, $secret_key);
+
+    // Save the signature into the release so it will be included in the project
+    // release history feed.
+    $release_node->project_release['download_signature'] = base64_encode($signature);
+  }
+}


### PR DESCRIPTION
Not yet functional. This includes a start on the changed necessary to all of the moving pieces to address https://github.com/backdrop/backdrop-issues/issues/1992 (MD5 and package signing support). Changes included:

- Backdrop core changes.
- Project Release module changes.
- BackdropCMS.org (borg_github.module) changes.

Once this firms up a bit more we can file separate PRs to each separate project.

The means of actually signing a package are not solidified yet. This assumes that we would put a private key in a file directly on BackdropCMS.org's server. As suggested by @jlfranklin, a better way to do this would be to set up a stand-alone signing server that is locked down and only accessible via intranet so it is less likely to be compromised.