### PR TITLE
Issue #291: Keep admin bar at top of page.

### DIFF
--- a/config/staging/admin_bar.settings.json
+++ b/config/staging/admin_bar.settings.json
@@ -1,7 +1,7 @@
 {
     "_config_name": "admin_bar.settings",
     "margin_top": 1,
-    "position_fixed": 0,
+    "position_fixed": 1,
     "components": [
         "admin_bar.icon",
         "admin_bar.menu",


### PR DESCRIPTION
Fixes https://github.com/backdrop-ops/backdropcms.org/issues/291