### PR TITLE
Issue #689: Vertically-align logos on Try Backdrop page.

### DIFF
--- a/www/themes/borg/css/components-views.css
+++ b/www/themes/borg/css/components-views.css
@@ -419,6 +419,7 @@
   padding-bottom: 15px;
 }
 .view-platforms .col-md-5 {
+  align-self: center;
   text-align: center;
 }
 .view-platforms .top-bar {


### PR DESCRIPTION
Fixes https://github.com/backdrop-ops/backdropcms.org/issues/689