### PR TITLE
Issue 799: address missing releases on project page

### DIFF
--- a/www/modules/contrib/project/project_github/project_github.module
+++ b/www/modules/contrib/project/project_github/project_github.module
@@ -174,9 +174,6 @@ function project_github_node_presave(Node $node) {
   if (project_node_is_project($node) && $node->project['github_sync_readme']) {
     module_load_include('inc', 'project_github', 'project_github.pages');
     project_github_update_readme($node);
-    // Delete the cached project release table that appears on the node project
-    // page so that it will be rebuilt the next time that page is viewed.
-    cache('cache_project_release_download_table')->delete($node->nid);
   }
 }
 

--- a/www/modules/contrib/project/project_release/project_release.module
+++ b/www/modules/contrib/project/project_release/project_release.module
@@ -729,7 +729,7 @@ function project_release_node_delete(Node $node) {
  */
 function project_release_node_view($node, $view_mode, $langcode) {
   if (project_node_is_project($node)) {
-    if (!empty($node->project['releases_enabled']) && $view_mode !== 'rss' && $view_mode !== 'search_index') {
+    if (!empty($node->project['releases_enabled']) && !in_array($view_mode, array('rss', 'search_index', 'project_search'))) {
       $download_table = project_release_download_table($node->nid);
       if ($download_table) {
         $node->content['project_release_downloads'] = array(
@@ -1068,6 +1068,15 @@ function project_release_parse_version_extra($version_extra) {
 function project_release_download_table($pid, $_clear = FALSE) {
   if ($_clear || ($cache = cache_get($pid, 'cache_project_release_download_table')) === FALSE) {
     $output = views_embed_view('project_release_download_table', 'block', $pid);
+
+    // BEGIN DEBUGGING: a bit of instrumentation to detect when the project
+    // release table is generated empty, in which case no header will be in the
+    // output.
+    if (strpos($output, 'Recommended releases') === FALSE) {
+      watchdog('project_release', 'Missing releases for node @pid.', array('@pid' => $pid));
+    }
+    // END DEBUGGING
+
     cache_set($pid, $output, 'cache_project_release_download_table');
     return $output;
   }


### PR DESCRIPTION
This PR deals with https://github.com/backdrop-ops/backdropcms.org/issues/799. (Doesn't fully fix it, so we want the issue left open after this is merged.) It does three things:

1. Reverts [PR 800](https://github.com/backdrop-ops/backdropcms.org/pull/800), because that change didn't noticeably affect the problem.
2. Stops project search results from unnecessarily generating the project release download table for all modules in the search results. That table isn't shown in search results so it's not needed, so this change speeds up project search results and eliminates a code path that could be implicated in the problem of issue 800.
3. Adds some instrumentation to detect when an empty project release table is being generated and posts a watchdog entry. This information might help us further track down the problem (by knowing which modules, when, and what type of user).