### PR TITLE
#799 - Expand the instrumentation to detect missing releases

### DIFF
--- a/www/modules/contrib/project/project_release/project_release.module
+++ b/www/modules/contrib/project/project_release/project_release.module
@@ -1069,18 +1069,28 @@ function project_release_download_table($pid, $_clear = FALSE) {
   if ($_clear || ($cache = cache_get($pid, 'cache_project_release_download_table')) === FALSE) {
     $output = views_embed_view('project_release_download_table', 'block', $pid);
 
-    // BEGIN DEBUGGING: a bit of instrumentation to detect when the project
-    // release table is generated empty, in which case no header will be in the
-    // output.
+    // A bit of instrumentation to detect when the project release table is
+    // generated empty, in which case no header will be in the output.
     if (strpos($output, 'Recommended releases') === FALSE) {
-      watchdog('project_release', 'Missing releases for node @pid.', array('@pid' => $pid));
+      watchdog('project_release', 'Missing releases for node @pid from View.', array('@pid' => $pid));
     }
-    // END DEBUGGING
+    else {
+      watchdog('project_release', 'Releases present for node @pid from View.', array('@pid' => $pid));
+    }
 
     cache_set($pid, $output, 'cache_project_release_download_table');
-    return $output;
+    return '<!-- release download table from View -->' . $output;
   }
-  return $cache->data;
+  $output = $cache->data;
+
+    if (strpos($output, 'Recommended releases') === FALSE) {
+      watchdog('project_release', 'Missing releases for node @pid from cache.', array('@pid' => $pid));
+    }
+//     else {
+//       watchdog('project_release', 'Releases present for node @pid from cache.', array('@pid' => $pid));
+//     }
+
+  return '<!-- release download table from cache -->' . $output;
 }
 
 /**


### PR DESCRIPTION
Further instrumentation to test https://github.com/backdrop-ops/backdropcms.org/issues/799. Puts comments in the HTML and more watchdog commands in the log to try to pin down why the recommended releases block comes up empty.