### PR TITLE
Issue 820: Fix bad date in other releases on project page

### DIFF
--- a/config/staging/views.view.project_release_download_table.json
+++ b/config/staging/views.view.project_release_download_table.json
@@ -1063,7 +1063,7 @@
                         "id": "created",
                         "table": "node",
                         "field": "created",
-                        "relationship": "none",
+                        "relationship": "recommended_release",
                         "group_type": "group",
                         "ui_name": "",
                         "label": "Released",


### PR DESCRIPTION
Fixes https://github.com/backdrop-ops/backdropcms.org/issues/820.

Synchronize configuration after merging to apply the change.