### PR TITLE
Issue 824 - Add instrumentation to project release download table.

### DIFF
--- a/PATCHES.md
+++ b/PATCHES.md
@@ -35,6 +35,10 @@ project - restore missing releases sub-tab
   https://github.com/backdrop-contrib/project/issues/41
   https://github.com/backdrop-contrib/project/pull/44.patch
 
+project - add debugging code
+  https://github.com/backdrop-ops/backdropcms.org/issues/824
+  https://github.com/backdrop-ops/backdropcms.org/pull/825.patch
+
 restrict_abusive_words - prevent PHP notice
   https://github.com/backdrop-contrib/restrict_abusive_words/issues/1
   fix committed to -dev

--- a/PATCHES.md
+++ b/PATCHES.md
@@ -27,14 +27,6 @@ colorbox - Remove dependance on libraries API
   https://github.com/backdrop-contrib/colorbox/issues/9
   https://github.com/backdrop-contrib/colorbox/pull/10.patch
 
-project - change #type to easily style links
-  https://github.com/backdrop-contrib/project/issues/31
-  https://github.com/backdrop-contrib/project/pull/32.patch
-
-project - restore missing releases sub-tab
-  https://github.com/backdrop-contrib/project/issues/41
-  https://github.com/backdrop-contrib/project/pull/44.patch
-
 project - add debugging code
   https://github.com/backdrop-ops/backdropcms.org/issues/824
   https://github.com/backdrop-ops/backdropcms.org/pull/825.patch

--- a/www/modules/contrib/project/project_release/project_release.module
+++ b/www/modules/contrib/project/project_release/project_release.module
@@ -1068,8 +1068,22 @@ function project_release_parse_version_extra($version_extra) {
 function project_release_download_table($pid, $_clear = FALSE) {
   if ($_clear || ($cache = cache_get($pid, 'cache_project_release_download_table')) === FALSE) {
     $output = views_embed_view('project_release_download_table', 'block', $pid);
-    cache_set($pid, $output, 'cache_project_release_download_table');
-    return $output;
+
+    // DEBUGGING: only cache the output if it contains at least one release. If
+    // it doesn't, post a notice in watchdog. We can look for these notices and
+    // then see if anything suspicious got posted shortly before; meanwhile, we
+    // won't be caching the bogus Views so visitors are more likely to see the
+    // page with proper releases (given the sporadic nature of the bug). (Note
+    // that there are a small number of projects that truly have no releases.)
+    if (strpos($output, 'Recommended releases') !== FALSE || strpos($output, 'Other releases') !== FALSE) {
+      cache_set($pid, $output, 'cache_project_release_download_table');
+      return $output;
+    }
+    else {
+      watchdog('project_release', 'Missing releases for node @pid.', array('@pid' => $pid));
+      return $output;
+    }
+
   }
   return $cache->data;
 }


### PR DESCRIPTION
Fixes https://github.com/backdrop-ops/backdropcms.org/issues/824.