### PR TITLE
Issue #867: Display resource links inline & fix Lando command.

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -33,7 +33,8 @@ tooling:
     cmd:
       - php /app/scripts/pull-db-files.php --files
       - tar -xzf backdropcmsorg-files-latest.tar.gz
-      - rm -r www/files/ && mv files/ www/
+      - rm -r www/files/ || true
+      - mv files/ www/
       - rm -f backdropcmsorg-files-latest.tar.gz
   phpcs:
     service: appserver

--- a/www/themes/backdropcms/css/components-blocks.css
+++ b/www/themes/backdropcms/css/components-blocks.css
@@ -116,7 +116,6 @@ main.col-md-8 .backdrop-books figure {
   padding-left: 38px;
 }
 .block-block-resources a {
-  display: block;
   line-height: 1.5em;
 }
 .block-block-resources i.fa {


### PR DESCRIPTION
Fixes https://github.com/backdrop-ops/backdropcms.org/issues/867