### PR TITLE
Issue #981: Harden CiviCRM template files against missing variables.

### DIFF
--- a/PATCHES.md
+++ b/PATCHES.md
@@ -32,3 +32,11 @@ markdown - PHP notice
 spambot - move last checked uid to state
   https://github.com/backdrop-contrib/spambot/issues/4
   https://github.com/backdrop-contrib/spambot/pull/5.patch
+
+Patches to CiviCRM:
+============================
+
+Templates: eliminate crashes and warnings when variables are not set
+  https://github.com/backdrop-ops/backdropcms.org/issues/981
+  https://lab.civicrm.org/dev/backdrop/-/issues/78
+  https://github.com/civicrm/civicrm-core/pull/25606.patch

--- a/www/modules/civicrm/templates/CRM/Contact/Form/Edit/TagsAndGroups.tpl
+++ b/www/modules/civicrm/templates/CRM/Contact/Form/Edit/TagsAndGroups.tpl
@@ -7,7 +7,7 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-{if $title}
+{if isset($title) && $title}
 <div class="crm-accordion-wrapper crm-tagGroup-accordion collapsed">
   <div class="crm-accordion-header">{$title}</div>
   <div class="crm-accordion-body" id="tagGroup">
@@ -15,7 +15,7 @@
     <table class="form-layout-compressed{if $context EQ 'profile'} crm-profile-tagsandgroups{/if}">
       <tr>
         <td>
-          {if $form.tag}
+          {if isset($form.tag) && $form.tag}
             <div class="crm-section tag-section">
               {if !empty($title)}{$form.tag.label}<br>{/if}
               {$form.tag.html}
@@ -47,7 +47,7 @@
         {/if}
       </tr>
     </table>
-{if $title}
+{if isset($title) && $title}
   </div>
 </div><!-- /.crm-accordion-wrapper -->
 {/if}

--- a/www/modules/civicrm/templates/CRM/Form/body.tpl
+++ b/www/modules/civicrm/templates/CRM/Form/body.tpl
@@ -15,7 +15,7 @@
   <div>{$form.hidden}</div>
 {/if}
 
-{if ($snippet !== 'json') and !$suppressForm and count($form.errors) gt 0}
+{if ($snippet !== 'json') and !$suppressForm and isset($form.errors) && count($form.errors) gt 0}
    <div class="messages crm-error">
        <i class="crm-i fa-exclamation-triangle crm-i-red" aria-hidden="true"></i>
      {ts}Please correct the following errors in the form fields below:{/ts}

--- a/www/modules/civicrm/templates/CRM/Profile/Form/Dynamic.tpl
+++ b/www/modules/civicrm/templates/CRM/Profile/Form/Dynamic.tpl
@@ -35,12 +35,12 @@
   <div id="crm-container" class="crm-container crm-public" lang="{$config->lcMessages|truncate:2:"":true}" xml:lang="{$config->lcMessages|truncate:2:"":true}">
   {/if}
 
-  {if $isDuplicate and ( ($action eq 1 and $mode eq 4 ) or ($action eq 2) or ($action eq 8192) ) }
+  {if isset($isDuplicate) && $isDuplicate and ( ($action eq 1 and $mode eq 4 ) or ($action eq 2) or ($action eq 8192) ) }
     <div class="crm-submit-buttons">
       {$form._qf_Edit_upload_duplicate.html}
     </div>
   {/if}
-  {if $mode eq 1 || $activeComponent neq "CiviCRM"}
+  {if $mode eq 1 || (isset($activeComponent) && $activeComponent neq "CiviCRM")}
     {include file="CRM/Form/body.tpl"}
   {/if}
   {strip}
@@ -50,7 +50,7 @@
     {if $action eq 2 and $multiRecordFieldListing}
       <h1>{ts}Edit Details{/ts}</h1>
       <div class="crm-submit-buttons" style='float:right'>
-      {include file="CRM/common/formButtons.tpl"}{if $isDuplicate}{$form._qf_Edit_upload_duplicate.html}{/if}
+      {include file="CRM/common/formButtons.tpl"}{if isset($isDuplicate) && $isDuplicate}{$form._qf_Edit_upload_duplicate.html}{/if}
       </div>
     {/if}
 
@@ -94,7 +94,7 @@
             <div class="content description">{$field.help_pre}</div>
           </div>
         {/if}
-        {if $field.options_per_line}
+        {if isset($field.options_per_line) && $field.options_per_line}
           <div class="crm-section editrow_{$n}-section form-item" id="editrow-{$n}">
             <div class="label">{$form.$n.label}</div>
             <div class="content edit-value">
@@ -201,7 +201,7 @@
         </div>
       {/if}
       <div class="crm-submit-buttons" style='{$floatStyle}'>
-        {include file="CRM/common/formButtons.tpl"}{if $isDuplicate}{$form._qf_Edit_upload_duplicate.html}{/if}
+        {include file="CRM/common/formButtons.tpl"}{if isset($isDuplicate) && $isDuplicate}{$form._qf_Edit_upload_duplicate.html}{/if}
         {if $includeCancelButton}
           <a class="button cancel" href="{$cancelURL}">
             <span>


### PR DESCRIPTION
Fixes https://github.com/backdrop-ops/backdropcms.org/issues/981.