### PR TITLE
Exclude .cspell directory from packager.

### DIFF
--- a/www/modules/custom/borg_github/borg_github.module
+++ b/www/modules/custom/borg_github/borg_github.module
@@ -288,6 +288,7 @@ function borg_github_project_github_create_package_alter(&$files, $project_name)
     '/\.gitattributes/',
 
     // Remove CI files not needed in distributed projects.
+    '/\.cspell\/.*/',
     '/\.gitlc\.yml/',
     '/\.gitlab\/.*/',
     '/\.gitlab-ci\.yml/',


### PR DESCRIPTION
To exclude .cspell from packaged projects including core.

See https://github.com/backdrop/backdrop-issues/issues/5811