### PR TITLE
Modify db query to correct recipients of security updates.

### DIFF
--- a/www/modules/custom/borg_mailers/borg_mailers_security/borg_mailers_security.module
+++ b/www/modules/custom/borg_mailers/borg_mailers_security/borg_mailers_security.module
@@ -111,9 +111,9 @@ function _borg_mailers_security_subscribers() {
     ->addSelect('uf_match.uf_id', 'email.email')
     ->addJoin('Email AS email', 'LEFT', ['email.contact_id', '=', 'contact_id'])
     ->addJoin('UFMatch AS uf_match', 'LEFT', ['uf_match.contact_id', '=', 'contact_id'])
-    ->addJoin('GroupContact AS group_contact', 'LEFT', ['group_contact.id', '=', 'contact_id'])
     ->addWhere('group_id', '=', 6)
-    ->addWhere('group_contact.status', '=', 'Added')
+    ->addWhere('status', '=', 'Added')
+    ->addWhere('contact_id.is_opt_out', '=', FALSE)
     ->execute();
   $to = [];
   foreach ($groupContacts as $groupContact) {


### PR DESCRIPTION
Fixes https://github.com/backdrop-ops/backdropcms.org/issues/1101.

Remove superfluous join to group_contact. Add “where” clause to respect the opt-out of all email setting.